### PR TITLE
Add Japanese translations to part-c.yaml through part-i.yaml

### DIFF
--- a/part-c.yaml
+++ b/part-c.yaml
@@ -1,449 +1,562 @@
 part:
   de: Handel und Wandel.
+  ja: 商売と取引。
 sections:
   - title:
       de: Er will Geld
+      ja: 彼はお金が欲しい
     conversations:
       - modern:
         - de: Er will etwas haben.
+          ja: 何か手に入れたい。
         grc:
           - αἰτεῖ λαβεῖν τι.
       - modern:
         - de: Er hat Alles, was er braucht.
+          ja: 必要なものはすべて持っている。
         grc:
           - ἔχει ἅπαντα, ἃ δεῖ.
       - modern:
         - de: Was wünschen Sie?
+          ja: 何をご希望ですか。
         grc:
           - \emph{τοῦ δέει;}
       - modern:
         - de: Wes\textcompwordmark{}halb sind Sie hergekommen?
+          ja: なぜここに来られたのですか。
         grc:
           - τοῦ δεόμενος ἦλθες ἐνθαδί;
           - ἥκεις κατὰ τί;
       - modern:
         - de: Was hat Sie hergeführt?
+          ja: 何の用でここへ？
         grc:
           - ἐπὶ τί πάρει δεῦρο;
       - modern:
         - de: Ich bitte Sie, leihen Sie mir 20 Mark!
+          ja: ２０マルク貸してください！
         grc:
           - δάνεισόν μοι πρὸς τῶν θεῶν εἴκοσι μάρκας{*}!
       - modern:
         - de: Die Noth zwingt mich dazu.
+          ja: やむにやまれぬ事情なのです。
         grc:
           - ἡ ἀνάγκη με πιέζει.
       - modern:
         - de: Nein!
+          ja: いやだ！
         grc:
           - "μὰ Δί' ἐγὼ μὲν οὔ!"
       - modern:
         - de: Sie haben, was Sie brauchen.
+          ja: 必要なものはもう持っていますよ。
         grc:
           - ἔχεις ὧν δέει.
       - modern:
         - de: So helfen Sie mir doch!
+          ja: どうか助けてください！
         grc:
           - οὐκ ἀρἠξεις;
       - modern:
         - de: Haben Sie Mitleid mit mir!
+          ja: どうか同情してください！
         grc:
           - οἴκτειρόν με!
       - modern:
         - de: Was wollen Sie mit dem Gelde machen?
+          ja: そのお金で何をするのですか。
         grc:
           - \emph{τί χρήσει τῷ} ἀργυρίῳ;
       - modern:
         - de: Ich will meinen Schuhmacher bezahlen.
+          ja: 靴屋に支払いをしたいのです。
         grc:
           - ἀποδώσω τῷ σκυτοτόμῳ.
       - modern:
         - de: Woher soll ich das Geld bekommen?
+          ja: そのお金をどこで手に入れろというのですか。
         grc:
           - πόθεν τὸ ἀργύριον λήψομαι;
       - modern:
         - de: Hier haben Sie es!
+          ja: はい、どうぞ。
         grc:
           - ἰδοὺ τουτὶ λαβέ!
       - modern:
         - de: Haben Sie vielen Dank!
+          ja: 本当にありがとうございます。
         grc:
           - "εὖ γ' ἐποίησας!"
       - modern:
         - de: Der Himmel segne Sie tausendmal!
+          ja: 天があなたに千回の祝福を！
         grc:
           - "πόλλ' ἀγαθὰ γένοιτό σοι!"
       - modern:
         - de: Seien sie nicht böse, mein Lieber!
+          ja: どうか怒らないで、お頼みです！
         grc:
           - "μὴ ἀγανάκτει, ὦ 'γαθέ!"
       - modern:
         - de: \emph{Seien sie so gut} und sprechen Sie nicht davon!
+          ja: どうかご親切に、このことは口にしないでください。
         grc:
           - "\\emph{οἶσθ' ὁ δρᾶσον;} μὴ διαλέγου περι τούτοθ μηδέν!"
       - modern:
         - de: Aber ich bitte Sie —!
+          ja: ですが、お願いします——！
         grc:
           - "ἀλλ' ὦ 'γαθέ —!"
   - title:
       de: Der Hausirer
+      ja: 行商人
     conversations:
       - modern:
         - de: Da kommt der Jude wieder!
+          ja: またあのユダヤ人が来た！
         grc:
           - καὶ μὴν ὁδὶ ἐκεῖνος ὁ Ἰουδαῖος!
       - modern:
         - de: "Schöne Portemonnaies! Schlipfe\\footnote{Redacteur: \\quotedblbase Shlipfe`` wird im Original verwendet.}! Messer!"
+          ja: 立派な財布！ ネクタイ！ ナイフだよ！
         grc:
           - βαλάντια καλά! λαιμοδέτια!{*} μαχαίρια!
       - modern:
         - de: Was soll ich für dies hier zahlen?
+          ja: これはいくら払えばいい？
         grc:
           - τί δῆτα καταθῶ τουτοί;
       - modern:
         - de: Zwei Mark fünfzig.
+          ja: ２マルク５０だ。
         grc:
           - δύο μάρκας{*} καὶ πεντήκοντα.
       - modern:
         - de: Nein, das ist zuviel.
+          ja: いや、それは高すぎる。
         grc:
           - "μὰ Δί', ἀλλ' ἔλαττον."
       - modern:
         - de: Geben Sie zwei Mark darür!
+          ja: ２マルクで譲ってくれ！
         grc:
           - δύο μάρκας τελεῖς;
       - modern:
         - de: Hier haben Sie 1 Mark 50 Pf.
+          ja: ほら、１マルク５０ペニヒだ。
         grc:
           - λαβὲ μάρκην καὶ ἡμίσειαν.
       - modern:
         - de: Was kosten die Portemonnaies?
+          ja: 財布はいくらですか。
         grc:
           - πῶς τὰ βαλάντια ὤνια;
       - modern:
         - de: Für 4 Mark können Sie ein ganz schönes bekommen.
+          ja: ４マルクならなかなか良いものが買えます。
         grc:
           - λήψει τεσσάρων μαρκῶν πάνυ καλόν.
       - modern: # ToDo: Fix
         - de: Nehmen Sie es wieder mit, ich kaufe es nicht. — Sie wollen \emph{zu vie}l profitiren.
+          ja: 持って帰ってくれ、買わないよ。—あんたは儲けすぎだ。
         grc:
           - ἀπόφερε· οὐκ ὠνήσομαι. κερδαίνειν γὰρ βούλει \emph{πολύ.}
       - modern:
         - de: Was bieten Sie gutwillig?
+          ja: いくらなら気前よく出すんだい？
         grc:
           - \emph{αὐτὸς} σὺ τί δίδως;
       - modern:
         - de: Was ich biete? Zwei Mark würde ich geben.
+          ja: 出せるのは？ ２マルクなら払うよ。
         grc:
           - ὅτι δίδωμι; δοίην ἂν δύο μάρκας.
       - modern:
         - de: Da nehmen Sie es; denn es ist immer besser als nichts zu lösen.
+          ja: じゃあ持っていきなさい。何も売れないよりましだ。
         grc:
           - ἔνεγκε τοίνυν· κρεῖττον γάρ ἐστιν ἢ μηδὲν λαβεῖν.
       - modern:
         - de: Wir werden den Kerl nicht wieder los!
+          ja: この男、なかなか帰ってくれない！
         grc:
           - ἅνθρωπος οὐκ ἀπαλλαχθήσεται ἡμῶν.
       - modern:
         - de: Das Messer taugt nichts; ich würde nicht 1 Mark dafür geben.
+          ja: このナイフは駄目だ、１マルクでも買わないね。
         grc:
           - οὐδέν ἐστιν ἡ μάχαιρα· οὐκ ἂν πριαίμην οὐδὲ μιᾶς μάρκης.!
       - modern:
         - de: Ich habe selbst seiner Zeit 3 Mark dafür gegeben.
+          ja: これには私自身昔３マルク払ったんだ。
         grc:
           - αὐτὸς ἀντέδωκα τούτου ποτὲ τρεῖς μάρκας.
       - modern:
         - de: Ich verdiene nichts daran.
+          ja: これでは儲けがない。
         grc:
           - οὐδέν μοι περιγίγνεται.
       - modern:
         - de: Wirklich?
+          ja: 本当かい？
         grc:
           - ἄληθες;
       - modern:
         - de: Schwören Sie einmal!
+          ja: 一度誓ってみろ！
         grc:
           - ὄμοσον!
       - modern:
         - de: Bei Gott!
+          ja: 神にかけて！
         grc:
           - οὐ μὰ τοὺς θεούς!
       - modern:
         - de: Verkaufen Sie es an einen Andern!
+          ja: 別の人に売りなさい。
         grc:
           - πώλει τοῦτο ἄλλῳ τινί!
       - modern:
         - de: Ich will es Ihnen \emph{abkaufen}.
+          ja: 私があなたから買い取ろう。
         grc:
           - ὠνήσομαί \emph{σοι} ἐγώ.
       - modern:
         - de: Da haben Sie das Geld.
+          ja: ほら、代金だ。
         grc:
           - ἔχε δὴ τἀργύριον.
       - modern:
         - de: Das wäre abgemacht.
+          ja: それで話はついた。
         grc:
           - \emph{ταῦτα} δή.
       - modern:
         - de: Ich habe 3 Mark \emph{dafür} bezahlt.
+          ja: それに３マルク払った。
         grc:
           - ἀπέδοκα \emph{ὀφείλων} τρεῖς μάρκας.
       - modern:
         - de: In Leipzig verkauft man das Dutzend für 20 Mark.
+          ja: ライプツィヒではダースで２０マルクで売っている。
         grc:
           - ἐν Λειψίᾳ{*} πωλοῦνται κατὰ δώδεκα εἴκοσι μαρκῶν.
       - modern:
         - de: Das hier hat er für 1 Mark verkauft.
+          ja: これは１マルクで売った。
         grc:
           - τοδὶ ἀπέδοτο μιᾶς μάρκης.
   - title:
       de: Beim Schneider
+      ja: 仕立て屋で
     conversations:
       - modern:
         - de: Guten Tag!
+          ja: こんにちは。
         grc:
           - χαῖρε!
       - modern:
         - de: Guten Tag, mein Herr!
+          ja: こんにちは、ご主人。
         grc:
           - χαῖρε καὶ σύ!
       - modern:
         - de: Womit kann ich dienen?
+          ja: ご用件は何でしょう。
         grc:
           - ἥκεις δὲ κατὰ τί;
       - modern:
         - de: Was wünschen Sie?
+          ja: 何をご要望ですか。
         grc:
           - τοῦ δέει;
       - modern:
         - de: Ich brauche Rock und Hose.
+          ja: 上着とズボンが必要です。
         grc:
           - δέομαι ἱμαίου τε καὶ βρακῶν.
       - modern:
         - de: Das Hemd.
+          ja: シャツ。
         grc:
           - ὁ χιτών.
       - modern:
         - de: Der Hut.
+          ja: 帽子。
         grc:
           - ὁ πῖλος.
       - modern:
         - de: Der Überrock.
+          ja: 外套。
         grc:
           - τὸ ἐπάνω ἱμάτιον.
       - modern:
         - de: Die Stiefel.
+          ja: 長靴。
         grc:
           - τὰ ὑποδήματα.
       - modern:
         - de: Der Strumpf.
+          ja: 靴下。
         grc:
           - ἡ περικνημίς.
       - modern:
         - de: Das Taschentuch.
+          ja: ハンカチ。
         grc:
           - τὸ ῥινόμακτρον.
       - modern:
         - de: Was soll ich \emph{dafür} zahlen?
+          ja: それにはいくら払えばいいですか。
         grc:
           - τί τελῶ ταῦτα \emph{ὠνούμενος;}
       - modern:
         - de: 50 Mark für einen Rock und 20 Mark für die Beinkleider.
+          ja: 上着５０マルク、ズボン２０マルクです。
         grc:
           - "πεντήκοντα μάρκας{*} εἰς ἱμάτιον, εἴκοσι δ' εἰς βράκας."
       - modern:
         - de: Hier ist ein sehr schöner Rock nebst Beinkleidern.
+          ja: ここにとても立派な上着とズボンがあります。
         grc:
           - κάλλιστον τοδὶ ἱμάτιον μετὰ βρακῶν.
       - modern:
         - de: Wird er mir passen?
+          ja: それは私に合いますか。
         grc:
           - "ἆρ' \\emph{ἁρμόσει} μοι;"
       - modern:
         - de: Legen Sie gefälligst ab!
+          ja: どうぞ上着をお脱ぎください。
         grc:
           - κατάθου δῆτα τὸ ἐπάνω ἱμάτιον.
       - modern:
         - de: Bitte, ziehen Sie einmal den Rock aus!
+          ja: どうか上着をお脱ぎください。
         grc:
           - ἀπόδυθι, ἀντιβολῶ, θοἰμάτιον!
           - βούλει ἀποδύεσθαι θοἰμάτιον;
       - modern:
         - de: Sie haben keinen neuen Rock an.
+          ja: あなたは新しい上着を着ていません。
         grc:
           - οὐ καινὸν ἀμπέχει ἱμάτιον.
       - modern:
         - de: Nein, der alte Rock hat Löcher.
+          ja: いや、この古い上着には穴があるんです。
         grc:
           - "οὐ μὰ Δί'· ἀλλ' ὀπὰς ἔχει τὸ τριβώνιον."
       - modern:
         - de: Was Sie nun für einen schönen Anzug haben!
+          ja: なんと立派な服装になったこと！
         grc:
           - ποίαν ἤδη ἔχεις σκευήν!
       - modern:
         - de: Der neue Rock sitzt vortrefflich.
+          ja: 新しい上着は実によく合っている。
         grc:
           - "ἄριστ' ἔχει τὸ καινὸν ἱμάτιον!"
       - modern:
         - de: Haben Sie etwas daran aus\textcompwordmark{}zusetzen?
+          ja: どこか気に入らないところはありますか。
         grc:
           - ἔχεις τι ψέγειν τούτου;
       - modern:
         - de: Er steht mir nicht.
+          ja: 似合いません。
         grc:
           - οὐ \emph{πρέπει} μοι.
   - title:
       de: Schuhwerk
+      ja: 履き物
     conversations:
       - modern:
         - de: Die Stiefel fehlen noch.
+          ja: まだ長靴が足りない。
         grc:
           - ὑποδημάτων δεῖ.
       - modern:
         - de: Nimm hier meine!
+          ja: ほら、私のを履きなさい。
         grc:
           - τἀμὰ ταυτὶ λάμβανε!
       - modern:
         - de: "Erst zieh' diesen an!"
+          ja: まずこれを履きなさい！
         grc:
           - τοῦτο πρῶτον ὑποδύου.
       - modern:
         - de: "Zieh' endlich die Stiefel an!"
+          ja: さっさと長靴を履きなさい！
         grc:
           - ἄνυσον ὑποδυσάμενος!
       - modern:
         - de: "Zieh' die Stiefeletten aus!"
+          ja: その短靴を脱ぎなさい！
         grc:
           - ἀποδύου τὰς ἐμβάδας (τὰ ἐμβάδια).
       - modern:
         - de: "Zieh' diese hier an!"
+          ja: これを履きなさい！
         grc:
           - ὑπόδυθι τάσδε.
       - modern:
         - de: Passen sie?
+          ja: 合うかい？
         grc:
           - "ἆρ' ἁρμόττουσιν."
       - modern:
         - de: Ja, sie sitzen vortrefflich.
+          ja: ああ、とてもぴったりだ。
         grc:
           - "νὴ Δί', ἀλλ' ἄριστ' ἔχει."
       - modern:
         - de: Wo haben Sie das Paar Stiefeletten gekauft, das Sie anhaben?
+          ja: その履いている短靴はどこで買ったのですか。
         grc:
           - πόθεν πριάμενος τὸ ζεῦγος ἐμβάδων τουτὶ φορεῖς;
       - modern:
         - de: Auf \emph{dem} Markte.
+          ja: 市場で。
         grc:
           - ἐν ἀγορᾷ.
       - modern:
         - de: Für wieviel?
+          ja: いくらで？
         grc:
           - καὶ πόσου;
       - modern:
         - de: Für 16 Mark.
+          ja: １６マルクで。
         grc:
           - ἑκκαίδεκα μαρκῶν{*}.
   - title:
       de: Vom Obstmarkt
+      ja: 果物市場で
     conversations:
       - modern:
         - de: Ich muß auf \emph{den} Markt gehen.
+          ja: 市場へ行かなければならない。
         grc:
           - εἰς ἀγορὰν βαδιστέον μοι.
       - modern:
         - de: Wes\textcompwordmark{}halb?
+          ja: なぜ？
         grc:
           - τίνος ἕνεκα;
       - modern:
         - de: Sie geht auf den Markt, um Trauben zu holen.
+          ja: 彼女はぶどうを買いに市場へ行く。
         grc:
           - χωρεῖ εἰς ἀγορὰν ἐπὶ βότρυς.
       - modern:
         - de: Ich will sie kaufen, wenn du mir das Geld giebst.
+          ja: お金をくれるなら、私がそれを買おう。
         grc:
           - ὠνήσομαι, ἐὰν σύ μοι δῷς τἀργύριον.
       - modern:
         - de: Da hast du ein paar Groschen!
+          ja: ほら、小銭をいくつかやるよ。
         grc:
           - ἰδοὺ λαβὲ μικρὸν ἀργυρίδιον!
       - modern:
         - de: Was soll ich kaufen?
+          ja: 何を買えばいい？
         grc:
           - τί βούλει με πρίασθαι;
       - modern:
         - de: Wir wollen für dieses Geld Pfirsiche kaufen.
+          ja: このお金で桃を買おう。
         grc:
           - ὠνησόμεθα περσικὰ τούτου τοῦ ἀργυρίου.
       - modern:
         - de: \myafterpagetrue\mysetaligntext{german}{Kaufe mir{ }}\mysetalign{german}Äpfel.
+          ja: リンゴを私に買ってきて。
         grc:
           - \mysetaligntext{greek}{\textgreek{ἀγόρασόν μοι}{ }}\mysetalign*{greek}\textgreek{μῆλα.}
       - modern:
         - de: \bgroup\mysetalign{german}Aprikosen.\par\egroup
+          ja: アプリコットを。
         grc:
           - \bgroup\mysetalign*{greek}ἀρμενιακά (μῆλα).\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Birnen.\par\egroup
+          ja: 梨を。
         grc:
           - \bgroup\mysetalign*{greek}ἄπια.\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Erdbeeren.\par\egroup
+          ja: イチゴを。
         grc:
           - \bgroup\mysetalign*{greek}χαμοκέρασα{*}.\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Gemüse.\par\egroup
+          ja: 野菜を。
         grc:
           - \bgroup\mysetalign*{greek}λάχανα.\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Kastanien.\par\egroup
+          ja: クリを。
         grc:
           - \bgroup\mysetalign*{greek}κάστανα.\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Kirschen.\par\egroup
+          ja: サクランボを。
         grc:
           - \bgroup\mysetalign*{greek}κεράσια.\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Wallnüsse.\par\egroup
+          ja: クルミを。
         grc:
           - \bgroup\mysetalign*{greek}κάρυα.\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Haselnüsse.\par\egroup
+          ja: ヘーゼルナッツを。
         grc:
           - \bgroup\mysetalign*{greek}λεπτοκάρυα.\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Pfirsiche.\par\egroup
+          ja: 桃を。
         grc:
           - \bgroup\mysetalign*{greek}περσικά (μῆλα).\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Pflaumen.\par\egroup
+          ja: スモモを。
         grc:
           - \bgroup\mysetalign*{greek}κοκκύμηλα (\textgerman{Kuckucks\textcompwordmark{}äpfel}).\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Apfelsinen.\par\egroup
+          ja: オレンジを。
         grc:
           - \bgroup\mysetalign*{greek}πορτοκάλια{*}. (\textgerman{Früchte aus Portugal.})\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Johannis\textcompwordmark{}beeren.\par\egroup
+          ja: スグリを。
         grc:
           - \bgroup\mysetalign*{greek}φραγγοστάφυλα{*}.\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Radies\textcompwordmark{}chen.\par\egroup
+          ja: ラディッシュを。
         grc:
           - \bgroup\mysetalign*{greek}ῥαφανίδια.\par\egroup
       - modern:
         - de: \bgroup\mysetalign{german}Alles Mögliche.\par\egroup
+          ja: いろいろなものを。
         grc:
           - \bgroup\mysetalign*{greek}\emph{πάντα.}\par\egroup
       - modern:
         - de: "Wieviel geben Sie für's Geld?"
+          ja: この金額でどれくらいくれますか。
         grc:
           - πόσον δίδως δῆτα τἀργυρίου;
       - modern:
         - de: Die Mandel für eine Mark.
+          ja: １マルクで十五個だ。
         grc:
           - πεντεκαίδεκα τῆς μάρκες.
       - modern:
         - de: Was kostet jetzt die Butter?
+          ja: 今、バターはいくらですか。
         grc:
           - |-
             πῶς ὁ βούτυρος (τὸ βούτυρον) το\footnote{\textlatin{%
@@ -451,25 +564,31 @@ sections:
             } νῦν ὤνιος.
       - modern:
         - de: Sie ist wohlfeil.
+          ja: 安いですよ。
         grc:
           - εὐτελής ἐστιν.
       - modern:
         - de: Wir müssen sie theuer kaufen.
+          ja: 高く買わざるを得ない。
         grc:
           - δεῖ τίμιον πρίασθαι αὐτόν.
       - modern:
         - de: Frische Butter, friesches Fleisch.
+          ja: 新鮮なバター、新鮮な肉だ。
         grc:
           - \emph{χλωρὸς} βούτυρος, χλωρὸν κρέας.
       - modern:
         - de: Ich habe noch nichts eingekauft.
+          ja: まだ何も買っていない。
         grc:
           - οὐδὲν ἠμπόληκά πω.
       - modern:
         - de: Wir haben etwas eingekauft und wollen nun nach Hause gehen.
+          ja: 少し買い物をしたので、もう家に帰ろう。
         grc:
           - "οἴκαδ' ἴμεν ἐμπολήσαντές τι."
       - modern:
         - de: Der Preis.
+          ja: 価格。
         grc:
           - ἡ τιμή.

--- a/part-d.yaml
+++ b/part-d.yaml
@@ -1,77 +1,96 @@
 part:
   de: In Gesellschaft.
+  ja: 交際にて
 sections:
   - title:
       de: Tanz
+      ja: ダンス
     conversations:
       - modern:
         - de: Sie tanzt gut; \emph{nicht wahr?}
+          ja: 彼女は上手に踊りますね？
         grc:
           - καλῶς ὀρχεῖται· ἦ γάρ;
       - modern:
         - de: Allerdings.
+          ja: そのとおり。
         grc:
           - μάλιστα.
       - modern:
         - de: Ich bin ent\textcompwordmark{}zückt.
+          ja: とても感激しています。
         grc:
           - κεκήλημαι ἔγωγε.
       - modern:
         - de: Ich werde Polka mit ihr tanzen (Schottisch, Walzer, Française).
+          ja: 彼女とポルカ（スコティッシュ、ワルツ、フランセーズ）を踊ります。
         grc:
           - |-
             ὀρχήσομαι μετ' αὐτῆς τὸ Πολωνικόν (τὸ Καληδονικόν, τὸ Γερμανικόν,
             τὸ Γαλλικόν).
       - modern:
         - de: Erlauben Sie mir diesen Tanz, gnädige Frau? (— Fräulein?)
+          ja: 奥様、この曲をご一緒してもよろしいですか？（――お嬢さん？）
         grc:
           - δὸς ὀρχεῖσθαι τοῦτο μετὰ σοῦ, ὦ γύναι! (--- ὦ κόρη!)
       - modern:
         - de: Recht gern!
+          ja: ええ、喜んで！
         grc:
           - \emph{φθόνος οὐδείς.}
       - modern:
         - de: Bitte, hören Sie auf, ich kann nicht mehr.
+          ja: すみません、もう踊れませんからやめてください。
         grc:
           - "παῦε δῆτ' ὀρχούμενος, !"
       - modern:
         - de: Ich bin müde.
+          ja: 疲れました。
         grc:
           - κέκμηκα.
       - modern:
         - de: Nur dies \emph{eine} Mal erlauben Sie mir noch!
+          ja: せめてあと\emph{一度}だけ許してください！
         grc:
           - "ἓν μὲν οὖν τουτί μ' ἔασον ὀρχήσασθαι."
       - modern:
         - de: Nun denn noch dies \emph{eine} Mal und nicht weiter!
+          ja: ではこれ\emph{一度}だけですよ、もうこれきりです！
         grc:
           - "τοῖτό νυν καὶ μηκέτ' ἄλλο μηδέν."
       - modern:
         - de: Das ist eine Lust, mit Ihnen zu tanzen!
+          ja: あなたと踊るのは本当に楽しいですね！
         grc:
           - ὡς ἡδὺ μετὰ σοῦ ὀρχεῖσθαι!
       - modern:
         - de: Wer ist eigentlich der Herr dort, der hierher sieht? der an der Thür steht?
+          ja: あそこでこちらを見ている、ドアのところにいる紳士は誰ですか？
         grc:
           - "τίς ποθ' ὅδεὁ δεῦρο βλέπων; \\emph{ὁ ἐπὶ} ταῖς θύραις;"
       - modern:
         - de: Es ist mein Mann.
+          ja: 私の夫です。
         grc:
           - ἐστὶν οὑμὸς ἀνήρ.
       - modern:
         - de: Warum macht er ein so verdrießliches Gesicht?
+          ja: なぜあんな不機嫌そうな顔をしているのですか？
         grc:
           - τί σκυθρωπάζει;
       - modern:
         - de: Er ist sehr eifersüchtig.
+          ja: とてもやきもち焼きなんです。
         grc:
           - σφόδρα ζηλότυπός ἐστιν.
       - modern:
         - de: Wir wollen gar nicht thun, als sähen wir ihn.
+          ja: 見えていないふりをしていましょう。
         grc:
           - μὴ ὁρᾶν δοκῶμεν αὐτόν.
       - modern:
         - de: Ich werde mich hüten!
+          ja: 気をつけます！
         grc:
           - |-
             φυλάξομαι\footnote{\textlatin{%
@@ -79,29 +98,36 @@ sections:
             }!
       - modern:
         - de: Den Männern ist ja nicht zu trauen!
+          ja: 男の人は信用できませんからね！
         grc:
           - οὐδὲν γὰρ πιστὸν τοῖς ἀνδράσιν.
       - modern:
         - de: Sie ist erst 3 Monate verheirathet.
+          ja: 彼女は結婚してまだ三か月です。
         grc:
           - νύμφη ἐστὶ τρεῖς μῆνας.
       - modern:
         - de: Der Tanzlehrer.
+          ja: ダンスの先生。
         grc:
           - ὁ ὀρχηστοδιδάσκαλος.
       - modern:
         - de: In die Tanzstunde.
+          ja: ダンスの授業へ。
         grc:
           - εἰς τὸ ὀρχηστοδιδασκαλεῖον.
   - title:
       de: Eine Geschichte
+      ja: ひとつの話
     conversations:
       - modern:
         - de: Hören Sie einmal zu, gnädige Frau, ich will Ihnen eine hübsche Geschichte erzählen.
+          ja: 奥様、ちょっとお聞きください、面白い話をいたしましょう。
         grc:
           - ἄκουσον, ὦ γύναι, λόγον σοι βούλομαι λέξαι χαρίεντα.
       - modern:
         - de: Nur zu, erzählen Sie!
+          ja: さあ、話してください！
         grc:
           - |-
             ἴθι\footnote{\textlatin{%
@@ -109,22 +135,27 @@ sections:
             } δὴ, λέξον.
       - modern:
         - de: Ist das wahr?
+          ja: 本当ですか。
         grc:
           - τί λέγεις;
       - modern:
         - de: Sie wundern sich?
+          ja: 驚きましたか？
         grc:
           - ἐθαύ\textit{μασας;}
       - modern:
         - de: Sie erzählen mir (erfundene) Geschichten!
+          ja: 作り話をしているのですね！
         grc:
           - μύθους μοι λέγεις!
       - modern:
         - de: Die Wahrheit wollen Sie doch nicht sagen!
+          ja: 本当のことを言いたくないのですね！
         grc:
           - τἀληθὲς γὰρ οὐκ ἐθέλεις φράσαι.
       - modern:
         - de: Wenn Sie wirklich die Wahrheit sprechen, so weiß ich nicht was ich sagen soll.
+          ja: もし本当に本当のことを言っているなら、何と言えばいいか分かりません。
         grc:
           - |-
             εἴπερ ὄντως σὺ\footnote{\textlatin{%
@@ -132,26 +163,32 @@ sections:
             } ταῦτ' ἀληθῆ λέγεις, οὐδὲν ἔχω εἰπεῖν.
       - modern:
         - de: Nach dem, was Sie sagen, muß man sie bewundern.
+          ja: あなたの話を聞くと、彼女は賞賛されるべきですね。
         grc:
           - κατὰ τὸν λόγον, ὃν σὺ λέγεις, ἀξία ἐστὶ θαυμάσαι.
       - modern:
         - de: Reden Sie mit ihr \emph{von} der Sache!
+          ja: その件について彼女に話してください！
         grc:
           - "λέγ' αὐτῇ τὸ πρᾶγμα."
       - modern:
         - de: Sagen = angeben.
+          ja: 伝える＝述べる。
         grc:
           - φράζειν.
       - modern:
         - de: Was hat sie darauf erwidert?
+          ja: それについて彼女は何と返事しましたか。
         grc:
           - τί πρὸς ταῦτα εἶπεν;
       - modern:
         - de: Sie macht Aus\textcompwordmark{}flüchte.
+          ja: 彼女は言い訳をします。
         grc:
           - προφασίζεσται.
       - modern:
         - de: Ich will euch ein Märchen erzählen nämlich —
+          ja: ではおとぎ話を聞かせましょう、つまり——
         grc:
           - |-
             μῦθον ὑμῖν βούλομαι λέξαι οὕτως\footnote{\textlatin{%
@@ -159,357 +196,447 @@ sections:
             }.
   - title:
       de: Ich weiß nicht
+      ja: 知らない
     conversations:
       - modern:
         - de: Ich weiß es nicht.
+          ja: 知りません。
         grc:
           - οὐκ οἶδα.
       - modern:
         - de: Ich kann es nicht sagen.
+          ja: それは言えません。
         grc:
           - οὐκ ἔχω φράσαι.
       - modern:
         - de: Worauf soll man rathen?
+          ja: 何を当てればいいのでしょうか。
         grc:
           - ποῖ τις ἂν τράποιτο;
       - modern:
         - de: Ich will es schon heraus\textcompwordmark{}bekommen.
+          ja: きっと突き止めてみせます。
         grc:
           - γνώσομαι ἔγωγε.
       - modern:
         - de: Ich weiß es nicht genau.
+          ja: 正確には知りません。
         grc:
           - "οὐκ οἶδ' ἀκριβῶς."
       - modern:
         - de: Nein, soviel ich weiß.
+          ja: いいえ、私が知る限りでは。
         grc:
           - "οὐχ, ὅσον γέ μ' εἰδέναι."
       - modern:
         - de: Ich weiß nicht sicher, wie es steht.
+          ja: どうなっているのか確かには知りません。
         grc:
           - "οὐ σάφ' οἶδα, ὅπως ἔχει."
       - modern:
         - de: Ich kann es nicht glauben.
+          ja: 信じられません。
         grc:
           - οὐ πείθομαι.
       - modern:
         - de: Ich weiß es ja.
+          ja: それは知っています。
         grc:
           - οἶδά τοι.
       - modern:
         - de: Ist mir bekannt!
+          ja: 承知しています！
         grc:
           - μεμνήμεθα!
       - modern:
         - de: Freilich weiß ich es!
+          ja: もちろん知っています！
         grc:
           - οἶδα μέντοι!
       - modern:
         - de: Da Sie es denn zu wissen verlangen, so will ich es sagen.
+          ja: 知りたいとおっしゃるならお話ししましょう。
         grc:
           - εἰ δὴ ἐπιθυμεῖς εἰδέναι, φράσω.
       - modern:
         - de: "Wär's möglich?"
+          ja: そんなことがあり得ますか？
         grc:
           - τί φής!
       - modern:
         - de: Ich habe es aus bester Quelle.
+          ja: 確かな筋から聞きました。
         grc:
           - "πέπυσμαι τοῦτο τῶν σάφ' εἰδότων."
       - modern:
         - de: Haben Sie bereits etwas von der Sache gehört?
+          ja: この件についてもう何か聞きましたか。
         grc:
           - "ἆρ' ἀκήκοάς τι τοῦ πράγματος;"
       - modern:
         - de: Das mußte ich (bis\textcompwordmark{}her noch) nicht.
+          ja: それはこれまで知りませんでした。
         grc:
           - "τοῦτ' οὐκ ᾔδειν ἐγώ."
       - modern:
         - de: \emph{O, dann begreife ich, daß} Sie verstimmt sind.
+          ja: \emph{ああ、そうなら}ご機嫌ななめなのも分かります。
         grc:
           - \emph{οὐκ ἐτὸς ἄρα} λυπεῖ.
   - title:
       de: Die Schöne und die Häßliche
+      ja: 美人と醜女
     conversations:
       - modern:
         - de: Sehen Sie die hier an, wie \emph{schön} sie ist!
+          ja: ここにいる彼女をご覧なさい、なんて\emph{きれい}なんでしょう！
         grc:
           - ὅρα ταυτηνὶ, ὡς καλή!
       - modern:
         - de: Wer ist wohl dort die Dame?
+          ja: あちらのご婦人はどなたでしょう？
         grc:
           - "τίς ποθ' αὑτηί;"
       - modern:
         - de: Die in dem grauen Kleide?
+          ja: 灰色の服を着ている人ですか？
         grc:
           - ἡ τὸ φαιὸν ἔνδυμα ἀμπεχομένη;
       - modern:
         - de: Sie ist die schönste (= blühendste) von allen.
+          ja: 彼女は皆の中でいちばん美しい（＝花盛り）です。
         grc:
           - πασῶν \emph{ὡραιοτάτη} ἐστίν.
       - modern:
         - de: Wer mag sie nur sein?
+          ja: いったい誰なのでしょう。
         grc:
           - τίς καί ἐστί ποτε;
       - modern:
         - de: Kennt sie Jemand von Ihnen?
+          ja: どなたか彼女をご存じですか。
         grc:
           - \emph{γιγνώσκει} τις ὑμῶν;
       - modern:
         - de: Ja, ich.
+          ja: はい、私です。
         grc:
           - νὴ Δία ἔγωγε.
       - modern:
         - de: Es ist meine Cousine.
+          ja: 彼女は私の従妹です。
         grc:
           - ἐστὶν ἀνεψιά μου.
       - modern:
         - de: Wie schön sie aus\textcompwordmark{}sieht!
+          ja: なんて美しく見えるのでしょう！
         grc:
           - οἷον τὸ κάλλος αὐτῆς φαίνεται!
       - modern:
         - de: Sie hat sehr gesunde Farbe.
+          ja: とても健康的な血色をしています。
         grc:
           - ὡς εὐχροεῖ!
       - modern:
         - de: Sie hat ein sanftes, schönes Auge.
+          ja: 優しく美しい眼差しですね。
         grc:
           - καὶ τὸ βλέμμα ἔχει μαλακὸν καὶ καλόν.
       - modern:
         - de: Und allerliebste Hände hat sie.
+          ja: それに本当に愛らしい手をしています。
         grc:
           - καὶ \emph{τὰς} χεῖρας παγκάλας ἔχει.
       - modern:
         - de: Sie lacht \emph{gern.}
+          ja: 彼女は\emph{よく}笑います。
         grc:
           - καὶ ἡδέως γελᾷ.
       - modern:
         - de: Ich bin in das Mädchen (die Dame) verliebt.
+          ja: その娘（ご婦人）に恋をしています。
         grc:
           - ἔρως με εἴληφε τῆς κόρης ταύτης.
       - modern:
         - de: Aber sie hat wohl nichts?
+          ja: でも、持参金がないのでは？
         grc:
           - "ἀλλ' ἔχει οὐδέν;"
       - modern:
         - de: O nein, sie ist reich; sie hat ein respectables Vermögen.
+          ja: いいえ、彼女は裕福で、かなりの財産があります。
         grc:
           - πλουτεῖ \emph{μὲν οὖν·} οὐσίαν γὰρ ἔχει συχνήν.
       - modern:
         - de: Weißt du, wem sie ganz ähnlich sieht? Der A.
+          ja: 彼女が誰にとてもよく似ているか分かる？　Aさんにそっくりです。
         grc:
           - "οὖσθ' ᾗ μάλιστ' ἔοικεν; τῇ Ἀ."
       - modern:
         - de: Dort ist ein schönes Mädchen! (Mädel!)
+          ja: あそこにきれいな娘さんがいる！（娘っ子だ！）
         grc:
           - ἐνταῦθα μείραξ ὡραία ἐστίν.
       - modern:
         - de: Wer ist denn die hinter ihr?
+          ja: では、その後ろにいる人は誰ですか。
         grc:
           - "τίς γάρ ἐσθ' ἡ ὄπισθεν αὐτῆς."
       - modern:
         - de: Wer die ist? Frau Schulze.
+          ja: あの人ですか？　シュルツェ夫人ですよ。
         grc:
           - ἥτις ἐστίν; Σχουλζίου γυνή.
       - modern:
         - de: Die Andere interessirt mich weniger.
+          ja: もう一人の方にはあまり興味がありません。
         grc:
           - τῆς ἑτέρας μοι ἧττον μέλει.
       - modern:
         - de: Sie ist häßlich.
+          ja: 彼女は醜いです。
         grc:
           - αἰσχρὰ γάρ ἐστιν.
       - modern:
         - de: Und hat eine stumpfe (kolbige) Nase.
+          ja: しかも団子鼻です。
         grc:
           - καὶ σιμή (ἐστιν).
       - modern:
         - de: Sie ist geschminkt.
+          ja: 化粧をしています。
         grc:
           - καὶ καταπεπλασμένη (ἐστίν).
       - modern:
         - de: sie riecht nach Pomade.
+          ja: ポマードの匂いがします。
         grc:
           - ὄζει δὲ μύρου.
       - modern:
         - de: Riechst du etwas?
+          ja: 何か匂いますか。
         grc:
           - ὀσφραίνει τι;
       - modern:
         - de: Die Pomade riecht nicht gut.
+          ja: このポマードはあまりいい香りではありません。
         grc:
           - οὐχ ἡδὺ τὸ μύρον τουτί.
   - title:
       de: Herr Schulze
+      ja: シュルツェ氏
     conversations:
       - modern:
         - de: Schulze heißt er? \emph{Was ist das für ein} Schulze?
+          ja: 彼はシュルツェというのですか？\emph{どんな}シュルツェ氏です？
         grc:
           - Σχούλζιος αὐτῷ ὄνομα; ποῖος οὗτος ὁ Σχούλζιος;
       - modern:
         - de: Kennen Sie ihn nicht?
+          ja: ご存じありませんか。
         grc:
           - οὐκ οἶσθα αὐτόν;
       - modern:
         - de: Nein, ich bin fremd hier und erst eben angekommen.
+          ja: いいえ、私はここではよそ者で、今着いたばかりです。
         grc:
           - οὐ μὰ Δία ἔγωγε, ξένος γάρ εἰμι ἀρτίως ἀφιγμένος.
       - modern:
         - de: Er spielt die erste Rolle in der Stadt.
+          ja: 彼はこの街で重要人物です。
         grc:
           - πράττει τὰ μέγιστα ἐν τῇ πόλει.
       - modern:
         - de: Er hat einen \emph{großen} Bart.
+          ja: 立派な髭を蓄えています。
         grc:
           - ἔχει δὲ πώγωνα.
       - modern:
         - de: Und graues Haar?
+          ja: それに白髪ですか。
         grc:
           - καὶ πολιός ἐστιν;
       - modern:
         - de: Wovon lebt er?
+          ja: 何で生計を立てているのですか。
         grc:
           - πόθεν διαζῇ;
       - modern:
         - de: Der Mann ist schnell reich geworben.
+          ja: 彼はあっという間に金持ちになりました。
         grc:
           - ταχέως ὁ ἀνὴρ γεγένηται πλούσιος.
       - modern:
         - de: Wodurch?
+          ja: どうやって？
         grc:
           - τί δρῶν;
       - modern:
         - de: |-
             Er hat ursprünglich ein Handwerk gelernt, dann wurde er Landwirth
             und jetzt ist er Kaufmann.
+          ja: |-
+            彼はもともと職人の技を学び、その後農夫になり、今は商人です。
         grc:
           - |-
             πρῶτον μὲν γὰρ τέχνην τιν' ἔμαθεν· εἶτα γεωργὸς ἐγένετο, νῦν δὲ ἔμπορός
             ἐστιν.
       - modern:
         - de: \myafterpagetrue\mysetaligntext{german}{Es ist{ }}\mysetalign{german}Fabrikant.
+          ja: \myafterpagetrue\mysetaligntext{german}{彼は{ }}\mysetalign{german}製造業者です。
         grc:
           - ἐργαστήριον ἔχει.
       - modern:
         - de: \bgroup\mysetalign{german}Arbeiter.\par\egroup
+          ja: \bgroup\mysetalign{german}職工。\par\egroup
         grc:
           - ἐργάτης
       - modern:
         - de: \bgroup\mysetalign{german}(Amts- etc.) Richter.\par\egroup
+          ja: \bgroup\mysetalign{german}（官職などの）裁判官。\par\egroup
         grc:
           - δικαστής.
       - modern:
         - de: \bgroup\mysetalign{german}Unterbeamter.\par\egroup
+          ja: \bgroup\mysetalign{german}下級官吏。\par\egroup
         grc:
           - ὑπάλληλος.
       - modern:
         - de: \bgroup\mysetalign{german}Rechts\textcompwordmark{}anwalt.\par\egroup
+          ja: \bgroup\mysetalign{german}弁護士。\par\egroup
         grc:
           - σύνδικος.
       - modern:
         - de: \bgroup\mysetalign{german}Apotheker.\par\egroup
+          ja: \bgroup\mysetalign{german}薬剤師。\par\egroup
         grc:
           - φαρμακοπώλης.
       - modern:
         - de: \bgroup\mysetalign{german}Banquier.\par\egroup
+          ja: \bgroup\mysetalign{german}銀行家。\par\egroup
         grc:
           - τραπεζίτης.
       - modern:
         - de: \bgroup\mysetalign{german}Officier.\par\egroup
+          ja: \bgroup\mysetalign{german}士官。\par\egroup
         grc:
           - ἀξιωματικός.
       - modern:
         - de: \bgroup\mysetalign{german}Schüler.\par\egroup
+          ja: \bgroup\mysetalign{german}生徒。\par\egroup
         grc:
           - μαθητής.
       - modern:
         - de: \bgroup\mysetalign{german}Student.\par\egroup
+          ja: \bgroup\mysetalign{german}学生。\par\egroup
         grc:
           - φοιτητής.
       - modern:
         - de: \bgroup\mysetalign{german}Lehrer.\par\egroup
+          ja: \bgroup\mysetalign{german}教師。\par\egroup
         grc:
           - διδάσκαλος.
       - modern:
         - de: \bgroup\mysetalign{german}Professor.\par\egroup
+          ja: \bgroup\mysetalign{german}教授。\par\egroup
         grc:
           - καθηγητής.
       - modern:
         - de: Er ist vom Lande.
+          ja: 彼は田舎出身です。
         grc:
           - ἐκ τῶν ἀγρῶν ἐστιν.
       - modern:
         - de: Er ist aus der Nachbarschaft.
+          ja: 近所の人です。
         grc:
           - ἐκ τῶν γειτόνων ἐστίν.
       - modern:
         - de: Mir ist er langweilig.
+          ja: 彼と一緒にいると退屈です。
         grc:
           - ἄχθομαι αὐτῷ συνὼν ἔγωγε.
       - modern:
         - de: Er ist nicht schlecht von Charakter.
+          ja: 性格は悪くありません。
         grc:
           - οὐ πονηρός ἐστι τοὺς τρόπους.
       - modern:
         - de: (Seht nur) wie protzig er hereingekommen ist!
+          ja: （ごらん）なんと尊大に入ってきたことでしょう！
         grc:
           - \emph{ὡς σοβαρὸς} εἰσελήλυθεν!
       - modern:
         - de: Es scheint mir nicht guter Ton zu sein, sich so zu betragen.
+          ja: あんな振る舞いは品がないと思います。
         grc:
           - οὐκ ἀστεῖόν μοι δοκεῖ εἶναι τοιτοῦτον ἑαυτὸν παρέχειν.
       - modern:
         - de: Aber N. N. ist wirklich ein Gentleman.
+          ja: でも○○氏は本当に紳士です。
         grc:
           - ὁ δὲ Ν. Ν. νὴ Δία γεννάδας ἀνήρ!
   - title:
       de: Wie alt?
+      ja: 何歳？
     conversations:
       - modern:
         - de: Er hat nur eine einzige Tochter.
+          ja: 彼には一人娘しかいません。
         grc:
           - θυγάτηρ αὐτῷ μόνη οὖσα τυγχάνει.
       - modern:
         - de: Wie alt ist sie?
+          ja: 彼女は何歳ですか。
         grc:
           - πηλίκη ἐστίν;
       - modern:
         - de: Sie ist über ein Jahr älter als du.
+          ja: 彼女は君より一年以上年上です。
         grc:
           - "πλεῖν ἢ 'νιαυτῷ σου πρεσβυτέρα ἐστίν."
       - modern:
         - de: Über 20 Jahre \emph{alt}.
+          ja: 20歳を\emph{超えています}。
         grc:
           - ὑπὲρ εἴκοσιν ἔτη \emph{γεγονυῖα.}
       - modern:
         - de: Du bist ein junger Mann \emph{von} 19 Jahren.
+          ja: 君は\emph{19歳の}若者です。
         grc:
           - σὺ δὲ ἀνὴρ νέος εἶ ἐννεακαίδεκα ἐτῶν.
       - modern:
         - de: Du mußt mit denen unter zwanzig tanzen.
+          ja: 20歳未満の人と踊らなければなりません。
         grc:
           - δεῖ οὖν ὀρχεῖσθαί σε μετὰ τῶν \emph{ἐντὸς} εἴκοσιν.
       - modern:
         - de: Sie sitzt dort bei den älteren Damen.
+          ja: 彼女はあそこで年配のご婦人たちのそばに座っています。
         grc:
           - ἐνταῦτα κάθηται παρὰ ταῖς πρεσβυτέραις γυναιξίν.
       - modern:
         - de: "Wo? zeig' einmal!"
+          ja: どこ？　見せて！
         grc:
           - τοῦ; δεῖξον!
       - modern:
         - de: Was hat sie für Toilette?
+          ja: どんな身なりをしていますか。
         grc:
           - "ποίαν τιν' ἔχει σκευήν;"
       - modern:
         - de: Ihre Mutter ist \emph{seit} 10 Jahren todt.
+          ja: 彼女の母は10年前に亡くなりました。
         grc:
           - τέθνηκεν ἡ μήτηρ αὐτῆς ἔτη δέκα.
       - modern:
         - de: Ihr Vater ist ein Sechziger.
+          ja: 父親は60代です。
         grc:
           - ἑξηκοντέτης ἐστὶν αὐτῆς ὁ πατήρ.
       - modern:
         - de: Die Familie.
+          ja: 家族。
         grc:
           - ὁ οἶκος.

--- a/part-e.yaml
+++ b/part-e.yaml
@@ -1,11 +1,14 @@
 part:
   de: Liebes\textcompwordmark{}glück und Liebes\textcompwordmark{}meh.
+  ja: 恋の幸せと恋の苦しみ
 sections:
   - title:
       de: Liebes\textcompwordmark{}sehnsucht
+      ja: 恋のあこがれ
     conversations:
       - modern:
         - de: Wie denken Sie über das Mädel?
+          ja: あの娘をどう思いますか。
         grc:
           - |-
             τί οὖν\footnote{\textlatin{%
@@ -13,52 +16,64 @@ sections:
             } ἐρεῖς περὶ τῆς μείρακος;
       - modern:
         - de: Alles nichts gegen meine Anna!
+          ja: うちのアンナに比べればたいしたことありませんよ。
         grc:
           - λῆρός ἐστι τἆλλα πρὸς Ἄνναν.
       - modern:
         - de: Die Sehnsucht nach Anna quält mich.
+          ja: アンナに会いたい気持ちが私を苦しめています。
         grc:
           - |-
             ἵμερός με (\textgerman{od.} πόθος
             με) διαλυμαίνεται Ἄννης.
       - modern:
         - de: Im Ernst?
+          ja: 本気ですか。
         grc:
           - ὢ τί λέτεις;
       - modern:
         - de: Du wunderst dich?
+          ja: 驚きましたか。
         grc:
           - ἐθαύ\emph{μασας};
       - modern:
         - de: Warum wunderst du dich?
+          ja: なぜ驚くのですか。
         grc:
           - τί ἐθαύμασας;
       - modern:
         - de: Wie schmerzlich für mich, daß sie nicht da ist!
+          ja: 彼女がいないのは私にはつらいことです。
         grc:
           - ὡς ἄχθομαι αὐτῆς ἀπούσης!
       - modern:
         - de: Sei kein Thor!
+          ja: ばかなことを言わないで。
         grc:
           - μὴ ἄφρων γένῃ!
       - modern:
         - de: Die Zeit wird mir lang, weil ich das herrliche Mädchen nicht sehe.
+          ja: あのすばらしい娘に会えないので時間が長く感じます。
         grc:
           - πάνυ πολύς μοι δοκεῖ εἶναι χρόνος, ὅτι οὐχ ὁρῶ αὑτὴν τοιαύτην οὖσαν.
       - modern:
         - de: Sie ist nicht hier.
+          ja: 彼女はここにいません。
         grc:
           - οὐκ ἐνθάδε ἐστίν.
       - modern:
         - de: Aber sie ist schon auf dem Wege.
+          ja: でも彼女はもう向かっているところです。
         grc:
           - "ἀλλ' ἔρχεται."
       - modern:
         - de: Da kommt sie!
+          ja: ほら、彼女が来ます。
         grc:
           - ἡδὶ προσέρχεται!
       - modern:
         - de: Jetzt sehe ich sie endlich.
+          ja: やっと彼女が見えました。
         grc:
           - |-
             νῦν\footnote{\textlatin{%
@@ -66,123 +81,153 @@ sections:
             } γε ἤδη καθορῶ αὐτήν.
       - modern:
         - de: Sie ist schon ziemlich lange da.
+          ja: 彼女はもうだいぶ前からそこにいますよ。
         grc:
           - \emph{ἥκει} ἐπιεικῶς πάλαι.
       - modern:
         - de: Das ist unerhört!
+          ja: とんでもないことです。
         grc:
           - ἄτοπον τουτὶ πρᾶγμα!
       - modern:
         - de: Was fällt dir ein?
+          ja: 何を考えているんだ。
         grc:
           - τί πάσχεις;
       - modern:
         - de: Siehst du nicht? N. lauft ihr nach. Er begrüßt sie angelegentlich!
+          ja: 見えませんか。Ｎが後を追って、丁寧に挨拶していますよ。
         grc:
           - οὐχ ὁρᾶς; Ν. ἀκολουθεῖ κατόπιν αὐτῆς καὶ ἀσπάζεται!
       - modern:
         - de: Das interessirt mich wenig.
+          ja: 私にはあまり関係ありません。
         grc:
           - ὀλίγον μοι μέλει.
       - modern:
         - de: Sie reicht ihm die Hand!
+          ja: 彼女が彼に手を差し出しています。
         grc:
           - ἡ δὲ δεξιοῦται αὐτόν.
       - modern:
         - de: Ach, ich Ärmster!
+          ja: ああ、かわいそうな私。
         grc:
           - οἴμοι κακοδαίμων.
       - modern:
         - de: Sie scheint dich nicht zu sehen.
+          ja: 彼女はあなたに気づいていないようです。
         grc:
           - οὐ δοκεῖ ὁρᾶν σε.
       - modern:
         - de: Sie hat ihm die Hand gegeben.
+          ja: 彼女は彼に手を渡しました。
         grc:
           - ἐνέβελε τὴν δεξιάν.
       - modern:
         - de: Kümmere dich nicht weiter um sie!
+          ja: 彼女のことはもう気にしないでください。
         grc:
           - ταύτην μὲν \emph{ἔα χαίρειν}!
       - modern:
         - de: Ich gehe. Ich will meine Tante begrüßen.
+          ja: 私は行きます。叔母に挨拶したいので。
         grc:
           - "ἀλλ' εἶμι· προσερῶ γὰρ τὴν τεθίδα."
       - modern:
         - de: Ich habe sie bereits begrüßt.
+          ja: もう彼女には挨拶しました。
         grc:
           - ἐγὼ δὲ προσείρηκα αὐτήν.
       - modern:
         - de: |-
             Das ist gar \emph{nicht schön} von Ihnen, \emph{daß} Sie mich nicht
             begrüßt haben.
+          ja: 私に挨拶しなかったとは、本当にひどいことですよ。
         grc:
           - καλῶς γε οὐ προσεῖπάς με! \textgerman{(ironisch.)}
   - title:
       de: Soll ich?
+      ja: どうしようか
     conversations:
       - modern:
         - de: Was gedenken Sie zu thun?
+          ja: 何をなさるおつもりですか。
         grc:
           - τί ποιεῖν διανοεῖ;
       - modern:
         - de: Was haben Sie vor?
+          ja: 何を企んでいるのですか。
         grc:
           - τί μέλλεις δρᾶν;
       - modern:
         - de: Geben Sie mir einen guten Rath!
+          ja: よい助言をください。
         grc:
           - χρηστόν τι συμβούλευσον!
       - modern:
         - de: Was soll ich machen?
+          ja: どうしたらよいでしょう。
         grc:
           - τί ποιήσω;
       - modern:
         - de: Ich fürchte, Sie werden es bereuen.
+          ja: それは後悔すると思いますよ。
         grc:
           - \emph{οἶμαί} σοι τοῦτο μεταμελήσειν.
       - modern:
         - de: Sehen Sie sich vor, daß sie Ihnen nicht entgeht.
+          ja: 彼女を逃さないよう気をつけてください。
         grc:
           - "εὐλαβοῦ, μὴ ἐκφύγῃ σ' ἐκείνη."
       - modern:
         - de: Jetzt ist es an Ihnen, das Weitere zu thun.
+          ja: あとはあなたが進める番です。
         grc:
           - \emph{σὸν ἔργον} τἆλλα ποιεῖν.
       - modern:
         - de: Was soll ich also?
+          ja: では私はどうすれば。
         grc:
           - τί οὖν κελεύεις δρᾶν με;
       - modern:
         - de: Sie müssen mit ihr sprechen, sobald sich Gelegenheit bietet.
+          ja: 機会があれば彼女と話さなくてはなりません。
         grc:
           - δεῖ διαλέγεσθαι αὐτῇ, ὅταν τύχῃς.
       - modern:
         - de: Gerade das will ich ja!
+          ja: まさにそれを望んでいるのです。
         grc:
           - "τοῦτ' αὐτὸ γὰρ καὶ βούλομαι."
       - modern:
         - de: Aber soweit ist die Sache noch nicht.
+          ja: でもまだそこまで話は進んでいません。
         grc:
           - "ἀλλ' οὐκ ἔστι πω ἐν τούτῳ τὰ πράγματα."
       - modern:
         - de: Die Sache hat einen Haken.
+          ja: 事には落とし穴があります。
         grc:
           - ἔνι κίνδυνος ἐν τῷ πράγματι.
       - modern:
         - de: Ein schwieriger Punkt!
+          ja: やっかいな点ですね。
         grc:
           - χαλεπὸν τὸ πρᾶγμα!
       - modern:
         - de: Machen Sie sich keine Sorge!
+          ja: 心配しないでください。
         grc:
           - μὴ φροντίσῃς.
       - modern:
         - de: Nur nicht ängstlich!
+          ja: 気を揉まないように。
         grc:
           - μὴ δέδιθι.
       - modern:
         - de: Haben Sie keine Angst, mein Bester!
+          ja: 心配はいりませんよ。
         grc:
           - |-
             μηδὲν δέδιτι, ὦ τᾶν\footnote{\textlatin{%
@@ -190,10 +235,12 @@ sections:
             }.
       - modern:
         - de: Es wird Ihnen nichts passiren.
+          ja: 何も起こりはしません。
         grc:
           - οὐδὲν (γὰρ) πείσει.
       - modern:
         - de: An mir soll es nicht liegen.
+          ja: 私のせいにはさせませんよ。
         grc:
           - |-
             οὐ τοὐμὸν ἐμποδὼν ἔσται, ὦ τᾶν\footnote{\textlatin{%
@@ -201,278 +248,347 @@ sections:
             }.
       - modern:
         - de: Das will ich schon besorgen.
+          ja: それは私が引き受けます。
         grc:
           - μελήσει μοι τοῦτό γε.
   - title:
       de: Nur Muth!
+      ja: さあ勇気を
     conversations:
       - modern:
         - de: Beeilen Sie sich!
+          ja: 急いでください。
         grc:
           - σπεῦδέ νυν! ἔπειγέ νυν!
       - modern:
         - de: So beeilen Sie sich doch!
+          ja: さあ急いでくださいよ。
         grc:
           - οὔκουν ἐπείξει;
       - modern:
         - de: Zögern Sie nicht!
+          ja: ためらわないで。
         grc:
           - μὴ βράδυνε!
       - modern:
         - de: Machen Sie schnell!
+          ja: 手早くしてください。
         grc:
           - \emph{ἄνυε!}
       - modern:
         - de: So machen Sie doch schnell!
+          ja: 早くしてくださいよ。
         grc:
           - οὐκ ἀνύσεις;
       - modern:
         - de: Sie dürfen nicht zögern.
+          ja: ぐずぐずしてはいけません。
         grc:
           - οὐ μέλλειν χρή σε.
       - modern:
         - de: Wir wollen uns nicht aufhalten.
+          ja: ぐずぐずせずに行きましょう。
         grc:
           - μὴ διατρίβωμεν.
       - modern:
         - de: So halten Sie sich doch nicht auf!
+          ja: だから時間をつぶさないでください。
         grc:
           - οὐ μὴ διατρίψεις;
       - modern:
         - de: Jetzt gilt es!
+          ja: いまが肝心です。
         grc:
           - νῦν ὁ καιρός!
       - modern:
         - de: Nun so versuchen Sie es doch wenigstens!
+          ja: せめてやってみてください。
         grc:
           - ἀλλ᾽ οὖν πεπειράσθω γε.
       - modern:
         - de: "Auf Ihre Verantwortung hin will ich's thun."
+          ja: あなたの責任ということでやってみます。
         grc:
           - δράσω τοίνυν σοὶ πίσυνος.
       - modern:
         - de: Ich will es versuchen.
+          ja: やってみます。
         grc:
           - πειράσομαι.
       - modern:
         - de: Und wenn es den Kopf kostet!
+          ja: 命がけでも構いません。
         grc:
           - κἂν δέῃ μ᾽ ἀποθανεῖν!
       - modern:
         - de: Ich bin schon darüber.
+          ja: もう覚悟はできています。
         grc:
           - ἀλλὰ δρῶ τοῦτο.
       - modern:
         - de: Endlich ist es so weit!
+          ja: ついにその時が来ました。
         grc:
           - ἤδη ᾽στὶ τοῦτ᾽ ἐκεῖνο!
       - modern:
         - de: Und wenn sie Nein sagt und nicht will?
+          ja: もし彼女が嫌だと言ったら？
         grc:
           - κἂν μὴ φῇ μηδ᾽ ἐθελήσῃ;
       - modern:
         - de: Wir werden gleich sehen.
+          ja: すぐにわかるでしょう。
         grc:
           - εἰσόμεθ᾽ αὐτίκα.
       - modern:
         - de: Ich will gleich einmal sehen.
+          ja: ちょっと確かめてみます。
         grc:
           - ἐγὼ \emph{εἴσομαι.}
   - title:
       de: Liebes\textcompwordmark{}glück
+      ja: 恋の幸せ
     conversations:
       - modern:
         - de: Ich verehre Sie.
+          ja: あなたを慕っています。
         grc:
           - ἐραστής εἰμι σός.
       - modern:
         - de: Ist das wahr?
+          ja: 本当ですか。
         grc:
           - τί λέγεις;
       - modern:
         - de: Warum sagen Sie das?
+          ja: どうしてそんなことを言うのですか。
         grc:
           - τί τοῦτο λέγεις;
       - modern:
         - de: Weil ich Sie liebe.
+          ja: あなたを愛しているからです。
         grc:
           - ὁτιὴ φιλῶ λέγεις;
       - modern:
         - de: Wenn Sie mich wirklich von Herzen lieben, so sprechen Sie mit meiner Mutter.
+          ja: 本当に心から私を愛しているのなら、母に話してください。
         grc:
           - εἴπερ ὄντως ἐκ τῆς καρδίας με φιλεῖς, πρόσειπε τἡν μητέρα μου.
       - modern:
         - de: Erlauben Sie mir einen Kuß!
+          ja: キスさせてください。
         grc:
           - \emph{δός μοι} κύσαι. (δὸς κύσαι.)
       - modern:
         - de: Geben Sie mir einen Kuß! Bitte bitte!
+          ja: キスしてください、お願いです！
         grc:
           - κύσον με, ἀντιβολῶ!
       - modern:
         - de: Einen Kuß!
+          ja: キスをしてください！
         grc:
           - φέρε, σε κύσω!
       - modern:
         - de: |-
             Ich weiß zwar gewiß, daß die Mutter darüber böse sein wird, aber Ihnen
             zu Gefallen will ich es thun.
+          ja: 母が怒るのはわかっていますが、あなたのためにそうします。
         grc:
           - οἶδα μὲν σαφῶς, ὅτι ἡ μήτηρ ἀχθέσεται, σοῦ ἕνεκα τοῦτο δράσω.
       - modern:
         - de: Hören Sie auf!
+          ja: やめてください！
         grc:
           - παῦε! παῦε!
       - modern:
         - de: Wie glücklich bin ich!
+          ja: なんて幸せなんだろう。
         grc:
           - ὡς ἥδομαι!
       - modern:
         - de: Ach, daß mich nur dir Mutter nicht sieht!
+          ja: どうかお母さんに見つかりませんように。
         grc:
           - οἴμοι, ἡ μήτηρ ὅπως μή μ᾽ ὄψεται!
       - modern:
         - de: Wir sind ja allein (unter uns).
+          ja: ほら、二人きりですよ。
         grc:
           - \emph{αὐτοὶ} γάρ ἐσμεν.
       - modern:
         - de: Pst! Seien Sie still!
+          ja: しっ、静かに。
         grc:
           - ἤ ἤ· σιώπα.
       - modern:
         - de: Geben Sie mir die Hand!
+          ja: 手を握ってください。
         grc:
           - δός μοι τὴν χεῖρα τὴν δεξιάν.
       - modern:
         - de: Ich schwöre Ihnen ewige Treue!
+          ja: 永遠にあなたに忠実でいると誓います。
         grc:
           - οὐδέποτέ σ᾽ ἀπολείψειν φημί!
   - title:
       de: Die Schwiegermutter
+      ja: 義母
     conversations:
       - modern:
         - de: Was geht da vor? — Was ist das?
+          ja: そこで何が起きているのですか――これは何です？
         grc:
           - τί τὸ πρᾶγμα; — τουτὶ τί ἐστιν;
       - modern:
         - de: Allmächtiger Gott!
+          ja: 全能の神よ！
         grc:
           - ὦ Ζεῦ βασιλεῦ!
       - modern:
         - de: Verwünscht!
+          ja: ちくしょう！
         grc:
           - οἴμοι κακοδαίμων!
       - modern:
         - de: Wir sind verrathen!
+          ja: 私たちは露見してしまった！
         grc:
           - προδεδόμεθα!
       - modern:
         - de: Hier ist der schändliche Mensch!
+          ja: ここにそのろくでもない男がいます！
         grc:
           - οὗτος ὁ πανοῦργος!
       - modern:
         - de: Sind Sie verrückt?
+          ja: 気でも違ったのですか。
         grc:
           - τί ποιεῖς;
       - modern:
         - de: Was fällt Ihnen ein?
+          ja: 何を考えているのですか。
         grc:
           - τί πάσχεις;
       - modern:
         - de: O Sie Abscheulicher!
+          ja: ああ、なんて嫌な人！
         grc:
           - ὦ βδελυρὲ σύ!
       - modern:
         - de: Ereifern Sie sich nicht!
+          ja: 興奮しないでください。
         grc:
           - μὴ πρὸς ὀργήν!
       - modern:
         - de: Das ist eine Sünde und Schande!
+          ja: これは罪であり恥です！
         grc:
           - ἀνόσια ἐπάθομεν!
       - modern:
         - de: \emph{Nein,} über diese Unverschämtheit!
+          ja: いやはや、なんという無礼だ！
         grc:
           - ἆρ᾽ οὐχ ὕβρις ταῦτ᾽ ἐστὶ πολλή;
       - modern:
         - de: Hören Sie auf!
+          ja: やめてください。
         grc:
           - παῦε!
       - modern:
         - de: Gehen Sie Ihrer Wege!
+          ja: さっさと立ち去りなさい。
         grc:
           - ἄπιθ᾽ ἐκποδών!
       - modern:
         - de: Machen Sie, daß Sie hinaus\textcompwordmark{}kommen!
+          ja: 早く外へ出て行きなさい。
         grc:
           - οὐκ εἶ θύραζε;
       - modern:
         - de: Entfernen Sie sich doch!
+          ja: さあ離れてください。
         grc:
           - οὐκ ἄπει δῆτα ἐκποδών;
       - modern:
         - de: Gehen Sie zum Teufel!
+          ja: 地獄へ行け！
         grc:
           - ἐς κόρακας!
       - modern:
         - de: Fort mit Ihnen!
+          ja: 出て行け！
         grc:
           - ἄπερρε!
       - modern:
         - de: Der Teufel soll Sie holen!
+          ja: 悪魔に連れて行かれてしまえ！
         grc:
           - ἀπολεῖ κάκιστα!
       - modern:
         - de: So gehen Sie doch zum Teufel!
+          ja: だからさっさと地獄へ行け！
         grc:
           - οὐκ ἐς κόρακας;
       - modern:
         - de: Sie sind verrückt, Madame!
+          ja: 奥さん、あなたは狂っていますよ。
         grc:
           - παραπαίεις, ὦ γύναι.
           - ὦ γύναι, ὡς παραπαίεις!
       - modern:
         - de: Sie beleidigen mich!
+          ja: 私を侮辱しています！
         grc:
           - οἴμοι, ὡς ὑβρίζεις!
       - modern:
         - de: Pfui!
+          ja: けっ！
         grc:
           - αἰβοί!
       - modern:
         - de: Das soll Ihnen nicht so hingehen!
+          ja: そうはいきませんよ。
         grc:
           - οὔτοι καταπροίξει (τοῦτο δρῶν)!
       - modern:
         - de: Das soll Ihnen schlecht bekommen!
+          ja: 痛い目に遭いますよ。
         grc:
           - οὐ χαιρήσεις.
       - modern:
         - de: Das will ich Ihnen anstreichen!
+          ja: その無礼はこらしめてやります。
         grc:
           - ἐγώ σε παύσω τοῦ θράσους.
       - modern:
         - de: Nun, so mäßigen Sie sich doch!
+          ja: さあ、気持ちを抑えてください。
         grc:
           - ἀλλ᾽ ἀνάσχου!
       - modern:
         - de: Ist es nicht arg, daß Sie das thun?
+          ja: そんなことをするなんてひどくないですか。
         grc:
           - οὐ δεινὸν δῆτά σε τοῦτο δράσαι;
       - modern:
         - de: Das ist empörend!
+          ja: これは我慢ならない！
         grc:
           - οὐκ ἀνασχετὸν τοῦτο!
       - modern:
         - de: Verwünscht! was soll ich thun?
+          ja: ちくしょう、どうしたらいいんだ？
         grc:
           - οἴμοι, τί δράσω;
       - modern:
         - de: Sehen Sie, was Sie gethan haben?
+          ja: 自分が何をしたかわかりますか。
         grc:
           - ὁρᾷς, ἃ δέδρακας;
       - modern:
         - de: Sie sind schuld daran!
+          ja: それはあなたの責任です！
         grc:
           - |-
             σὺ τούτων αἴτιος\footnote{\textlatin{%
@@ -480,241 +596,301 @@ sections:
             }.
   - title:
       de: Wie ärgerlich!
+      ja: なんて腹立たしいんだ
     conversations:
       - modern:
         - de: Was hängst du den Kopf?
+          ja: どうしてそんなにうなだれているの？
         grc:
           - τί κύπτεις;
       - modern:
         - de: Ich schäme mich.
+          ja: 恥ずかしいんだ。
         grc:
           - αἰσχύνομαι.
       - modern:
         - de: Die Frau hat dich in der That sehr schlecht behandelt.
+          ja: あの女性は本当に君にひどい仕打ちをしたね。
         grc:
           - αἴσχιστά τοί σ᾽ εἰργάσατο ἡ γυνή.
       - modern:
         - de: Sie ist sehr böse auf uns.
+          ja: 彼女は私たちにひどく腹を立てている。
         grc:
           - ὀργὴν ἡμῖν ἔχει πολλήν.
       - modern:
         - de: Das ist höchst ärgerlich für uns.
+          ja: これは私たちにとって非常に腹立たしい。
         grc:
           - τοῦτ᾽ ἔστ᾽ ἄλγιστον ἡμῖν.
       - modern:
         - de: Ich ärgere mich immer wieder, daß ich das gethan habe.
+          ja: そんなことをした自分に、何度も腹が立つ。
         grc:
           - πόλλ᾽ ἄχθομαι, ὅτι ἔδρασα τοῦτο.
       - modern:
         - de: Das hatte ich nicht erwartet.
+          ja: こんなことになるとは思わなかった。
         grc:
           - τουτὶ μὰ Δί᾽ οὐδέποτ᾽ ἤλπισα.
       - modern:
         - de: Knirsche nicht mit den Zähnen!
+          ja: 歯ぎしりするのはやめなさい！
         grc:
           - μὴ πρῖε τοὺς ὀδόντας!
       - modern:
         - de: Das läßt sich nicht ändern.
+          ja: それはどうにもならない。
         grc:
           - ταῦτα μὲν δὴ ταῦτα.
       - modern:
         - de: Sei nicht rachsüchtig!
+          ja: 仕返ししようとしないで。
         grc:
           - μὴ μνησικακήσῃς.
       - modern:
         - de: Es ist am besten, wir bleiben ruhig.
+          ja: 静かにしているのが一番だ。
         grc:
           - ἡσυχίαν ἄγειν βέλτιστόν ἐστιν.
       - modern:
         - de: Das war ein Fehler von uns.
+          ja: それは私たちの過ちだった。
         grc:
           - ἡμάρτομεν ταῦτα.
       - modern:
         - de: Sei nicht böse, mein Lieber!
+          ja: 怒らないでおくれ。
         grc:
           - μὴ ἀγανάκτει, ὦ ᾽γαθέ.
       - modern:
         - de: Aber ich kann unmöglich schweigen.
+          ja: でも黙ってはいられないんだ。
         grc:
           - ἀλλ᾽ \emph{οὐκ ἔσθ᾽ ὅπως} σιγήσομαι.
       - modern:
         - de: Daran bist du ganz allein schuld.
+          ja: それはまったく君の責任だ。
         grc:
           - αἴτιος μέντοι σὺ τούτων εἶ μόνος.
       - modern:
         - de: Es war \emph{nicht richtig, daß} du das thatest.
+          ja: 君がそうしたのは間違いだった。
         grc:
           - οὐκ ὀρθῶς τοῦτ᾽ ἔδρασας!
       - modern:
         - de: Was geht das \emph{dich} an?
+          ja: それが君に何の関係があるんだ。
         grc:
           - τί δὲ σοὶ τοῦτο;
       - modern:
         - de: Was fiel dir denn ein, daß du das thatest?
+          ja: どういうつもりでそんなことをしたんだ。
         grc:
           - τί δὴ \emph{μαθὼν} τοῦτ᾽ ἐποίησας;
       - modern:
         - de: O über die Thorheit!
+          ja: なんという愚かさだ！
         grc:
           - τῆς μωρίας!
       - modern:
         - de: Wie \emph{unrecht} du gehandelt hast!
+          ja: 君のしたことはなんて間違っているんだ！
         grc:
           - ὡς οὐκ ὀρθῶς τοῦτ᾽ ἔδρασας!
       - modern:
         - de: Das war Unrecht von dir.
+          ja: それは君が悪かった。
         grc:
           - τοῦτ᾽ οὐκ ὀρθῶς ἐποίησας.
       - modern:
         - de: \emph{Das ist es, was} du mir zum Vorwurf machst?
+          ja: それを私に非難するのか？
         grc:
           - ταῦτ᾽ ἐπικαλεῖς;
       - modern:
         - de: Aber es ging nicht anders.
+          ja: でもそうするしかなかった。
         grc:
           - ἀλλ᾽ οὐκ ἦν παρὰ ταῦτ᾽ ἄλλα.
       - modern:
         - de: Gieb mir keine guten Lehren, sondern —
+          ja: 説教はいいから――
         grc:
           - μὴ νουθέτει με, ἀλλὰ —
       - modern:
         - de: Über dich kann man sich krank ärgern.
+          ja: 君には本当に腹が立って病気になりそうだ。
         grc:
           - ἀπολεῖς με!
       - modern:
         - de: "Aber soviel sage ich dir:"
+          ja: でもね、これだけは言っておくよ。
         grc:
           - ἓν δέ σοι λέγω·
       - modern:
         - de: Mir \emph{thut} das Fräulein \emph{leid.}
+          ja: あの娘が本当に気の毒だ。
         grc:
           - περὶ τῆς κόρης ἀνιῶμαι.
   - title:
       de: Keine schlechten Witze!
+      ja: ひどい冗談はやめて
     conversations:
       - modern:
         - de: Wie komisch sich das aus\textcompwordmark{}nahm!
+          ja: なんてばかばかしく見えたことか！
         grc:
           - ὡς καταγέλαστον ἐφάνη τὸ πρᾶγμα!
       - modern:
         - de: Das ist ein Hauptwitz!
+          ja: これは大笑いだ！
         grc:
           - τοῦτο πάνυ γελοῖον!
       - modern:
         - de: Das geht auf mich!
+          ja: これは私のことだ。
         grc:
           - πρὸς \emph{ἐμὲ} ταῦτ᾽ ἐστίν.
       - modern:
         - de: Er macht schlechte Witze.
+          ja: 彼はくだらない冗談を言う。
         grc:
           - σκώπτει.
       - modern:
         - de: "Mach' keine schlechten Witze!"
+          ja: くだらない冗談はやめろ！
         grc:
           - μὴ σκῶπτε!
       - modern:
         - de: "Mach' keine schlechten Witze \\emph{über mich!}"
+          ja: 私のことで変な冗談を言うな！
         grc:
           - μὴ σκῶπτέ με!
       - modern:
         - de: |-
             Du machst doch nicht etwa des\textcompwordmark{}wegen schlechte Witze
             über mich?
+          ja: まさかそれで私をからかっているのではないだろうね？
         grc:
           - μῶν με σκώπτεις ὁρῶν τοῦτο;
       - modern:
         - de: Laß dich doch nicht aus\textcompwordmark{}lachen!
+          ja: 笑いものになるなよ。
         grc:
           - καταγέλαστος εἶ.
       - modern:
         - de: Wir lachen nicht über dich.
+          ja: 君のことを笑っているわけじゃない。
         grc:
           - οὐ σοῦ καταγελῶμεν.
       - modern:
         - de: Nun, worüber denn?
+          ja: じゃあ何がおかしいんだい。
         grc:
           - ἀλλὰ τοῦ;
       - modern:
         - de: Worüber lachst du?
+          ja: 何を見て笑っているの？
         grc:
           - ἐπὶ τῷ γελᾶς;
       - modern:
         - de: "Hör' auf! — Schweig'!"
+          ja: やめろ！――黙れ！
         grc:
           - παῦε! — σιώπα!
       - modern:
         - de: Sei so gut und rede nicht mehr mit mir!
+          ja: 悪いがもう私に話しかけないでくれ。
         grc:
           - \emph{βούλει} μὴ προσαγορεύειν ἐμέ;
   - title:
       de: Ende gut, Alles gut!
+      ja: 終わりよければすべてよし
     conversations:
       - modern:
         - de: Vielleicht kann es noch gut werden!
+          ja: まだうまくいくかもしれません！
         grc:
           - ἴσως ἂν εὖ γένοιτο.
       - modern:
         - de: So Gott will.
+          ja: 神の御心のままに。
         grc:
           - σὺν θεῷ δ᾽ εἰρήσεται.
           - ἢν θεοὶ θέλωσιν.
       - modern:
         - de: Wer bürgt dir dafür?
+          ja: それを保証してくれるのは誰ですか。
         grc:
           - καὶ τίς ἐγγυητής ἐστι τούτου;
       - modern:
         - de: Wenn es uns gelingt, so will ich Gott innig denken.
+          ja: もしうまくいったら、神に心から感謝します。
         grc:
           - ἢν \emph{κατορθώσωμεν, ἐπαινέσομαι} τὸν θεὸν πάνυ σφόδρα.
       - modern:
         - de: Wie es sich gehört.
+          ja: そうあるべきですね。
         grc:
           - ὥσπερ εἰκός ἐστιν.
       - modern: # ToDo why colon?
         - de: In Gottes Namen!
+          ja: 神の御名によって！
         grc:
           - "τυχαγαθῇ:"
       - modern:
         - de: Wenn es uns aber mißlingt?
+          ja: でも失敗したらどうしますか。
         grc:
           - ἢν δὲ \emph{σφαλῶμεν;}
       - modern:
         - de: Hurrah! (Freudenruf.)
+          ja: フラー！ （歓声）
         grc:
           - ἀλαλαί!
       - modern:
         - de: Was du für \emph{Glück hast!}
+          ja: 君はなんて幸運なんだ！
         grc:
           - ὡς εὐτυχὴς εἶ!
       - modern:
         - de: Er hat großes Glück.
+          ja: 彼は大変ついている。
         grc:
           - εὐτυχέστατα πέπραγεν.
       - modern:
         - de: Inwiefern?
+          ja: どういう点で？
         grc:
           - τίνι τρόπῳ;
       - modern:
         - de: Er hat ein ganz junges Mädchen geheirathet.
+          ja: 彼はとても若い娘と結婚した。
         grc:
           - παῖδα κόρην γεγάμηκεν.
       - modern:
         - de: Er ist ein reicher Mann geworden.
+          ja: 彼は裕福な男になった。
         grc:
           - πλούσιος γεγένηται.
       - modern:
         - de: Er kann das Leben genießen.
+          ja: 人生を存分に楽しめる。
         grc:
           - ἔχει τῆς ἥβης ἀπολαῦσαι.
       - modern:
         - de: "Wenn's weiter nichts ist!"
+          ja: それだけのことかい？
         grc:
           - εἶτα τί τοῦτο;
       - modern:
         - de: Seine Freunde vermissen ihn schmerzlich.
+          ja: 友人たちは彼をひどく恋しがっている。
         grc:
           - ποθεινός ἐστι τοῖς φίλοις.
       - modern:
         - de: Er ist ein Freund von mir.
+          ja: 彼は私の友人だ。
         grc:
           - ἐστὶ \emph{τῶν} φίλων.

--- a/part-f.yaml
+++ b/part-f.yaml
@@ -1,510 +1,640 @@
 part:
   de: Im Hause.
+  ja: 家の中で
 sections:
   - title:
       de: Da wohnt er
+      ja: そこに彼は住んでいる
     conversations:
       - modern:
         - de: Werden Sie mir wohl sagen können, wo hier Herr M. wohnt?
+          ja: こちらでM氏がどこに住んでいるか教えていただけますか？
         grc:
           - ἔχοις ἂν φράσαι μοι (τόν κύριον{*}) Μύλλερον, ὅπου ἐνθάδε οἰκεῖ;
       - modern:
         - de: Ich möchte gern erfahren, wo Müller wohnt.
+          ja: ミュラーがどこに住んでいるか知りたいのですが。
         grc:
           - ἡδέως ἂν μάθοιμι, ποῦ Μύλλερος οἰκεῖ.
       - modern:
         - de: Das möchte ich gern wissen.
+          ja: それを知りたいのです。
         grc:
           - τοῦτ᾽ με δίδαξον!
       - modern:
         - de: In der Leipziger Straße.
+          ja: ライプツィヒ通りです。
         grc:
           - ἐν τῇ Λειψιανῇ{*} ὁδῷ.
       - modern:
         - de: Er zieht aus.
+          ja: 彼は引っ越します。
         grc:
           - μετοικίζεται.
       - modern:
         - de: Er ist aus\textcompwordmark{}gezogen.
+          ja: 彼はもう引っ越していきました。
         grc:
           - φροῦδός ἐστιν ἐξῳκισμένος.
       - modern:
         - de: Da sieht er zum Fenster heraus!
+          ja: ほら、窓から顔を出しています！
         grc:
           - ὁδὶ ἐκ θυρίδος παρακύπτει.
       - modern:
         - de: Das ist er.
+          ja: 彼だ。
         grc:
           - \emph{οὗτός ἐστ’ ἐκεῖνος.}
       - modern:
         - de: Wer klopft?
+          ja: 誰がノックしている？
         grc:
           - τίς ἐσθ’ ὁ τὴν θύραν κόπτων;
       - modern:
         - de: "Mach' die Thür auf!"
+          ja: ドアを開けろ！
         grc:
           - ἄνοιγε τὴν θύραν!
       - modern:
         - de: "Mach' doch auf!"
+          ja: さっさと開けて！
         grc:
           - οὐκ ἀνοίξεις;
       - modern:
         - de: "Mach' endlich die Thür auf!"
+          ja: いい加減ドアを開けろ！
         grc:
           - ἄνοιγ’ \emph{ἀνύσας} τὴν θύραν.
       - modern:
         - de: Wer ist da?
+          ja: 誰だ？
         grc:
           - τίς οὗτος;
       - modern:
         - de: Melden Sie mich!
+          ja: 私が来たと取り次いでください。
         grc:
           - εἰσάγγειλον.
       - modern:
         - de: Ich weiß Ihren Namen nicht genau.
+          ja: お名前をはっきり存じ上げません。
         grc:
           - οὐκ οἶδ’ ἀκριβῶς σου τοὔνομα.
       - modern:
         - de: Ist Müller zu Hause?
+          ja: ミュラーは家にいますか？
         grc:
           - \emph{ἔνδον} ἐστὶ Μύλλερος;
       - modern:
         - de: Nein, er ist nicht zu Hause.
+          ja: いいえ、留守です。
         grc:
           - οὐκ ἔνδον ἐστίν.
       - modern:
         - de: \emph{Augenblicklich} ist er nicht zu Hause.
+          ja: ちょうど今は家にいません。
         grc:
           - οὐκ ἔνδον ὢν τυγχάνει.
       - modern:
         - de: Er ist spazieren.
+          ja: 彼は散歩に出ています。
         grc:
           - περίπατον ποιεῖται.
       - modern:
         - de: So?
+          ja: そうですか？
         grc:
           - ἄληρες;
       - modern:
         - de: Er steht an der Thür.
+          ja: 彼は戸口に立っています。
         grc:
           - ἐπὶ ταῖς θύραις ἕστηκεν.
       - modern:
         - de: Er ist im Begriff aus\textcompwordmark{}zugehen.
+          ja: 彼は今まさに出かけようとしています。
         grc:
           - μέλλει \emph{θύραζε βαδίζειν.}
   - title:
       de: Am Morgen
+      ja: 朝
     conversations:
       - modern:
         - de: Er ist im Schlafzimmer.
+          ja: 彼は寝室にいます。
         grc:
           - ἐστὶν ἐν τῷ δωματίῳ.
       - modern:
         - de: Das Bett.
+          ja: ベッド。
         grc:
           - τὰ \emph{στρώματα.}
       - modern:
         - de: Im Bette.
+          ja: ベッドの中で。
         grc:
           - ἐν τοῖς στρώμασιν.
       - modern:
         - de: Er schläft eben.
+          ja: 彼はいま寝ています。
         grc:
           - ἀρτίως εὕδει.
       - modern:
         - de: "Du, wach' auf!"
+          ja: おい、起きろ！
         grc:
           - οὗτος, ἐγείρου!
       - modern:
         - de: "Steh' auf!"
+          ja: 起きなさい！
         grc:
           - ἀνίστασο!
       - modern:
         - de: Zünde Licht an!
+          ja: 明かりをつけて！
         grc:
           - ἅπτε λύχνον!
       - modern:
         - de: Sehr wohl.
+          ja: わかりました。
         grc:
           - ταῦτα.
       - modern:
         - de: Hast du dich gewaschen?
+          ja: もう洗ったかい？
         grc:
           - ἆρ᾽ ἀπονένιψαι;
       - modern:
         - de: Kannst du \emph{ohne} Handtuch zurechtkommen?
+          ja: タオルなしでやっていけるか？
         grc:
           - ἀνύτεις χειρόμακτρον οὐκ ἔχων;
       - modern:
         - de: Du siehst schrecklich schmutzig aus.
+          ja: ひどく汚れて見えるよ。
         grc:
           - αὐχμεῖς αἰσχρῶς.
       - modern:
         - de: Er hat sich nicht gebadet.
+          ja: 彼は風呂に入らなかった。
         grc:
           - οὐκ ἐλούσατο.
       - modern:
         - de: "Wisch' den Tisch ab!"
+          ja: テーブルを拭け！
         grc:
           - ἀποκάθαιρε τὴν τράπεζαν!
       - modern:
         - de: Ich will zu hause bleiben.
+          ja: 家にいたい。
         grc:
           - οἴκοι μενῶ.
       - modern:
         - de: Wir wollen zu Hause bei mir studiren.
+          ja: 今日は私の家で勉強しよう。
         grc:
           - ἔνδον παρ᾽ ἐμοὶ διατρίψομεν (περὶ τὰ μαθήματα).
       - modern:
         - de: Bei dir?
+          ja: 君の家で？
         grc:
           - παρὰ σοί;
       - modern:
         - de: Ganz recht.
+          ja: そうだ。
         grc:
           - πάνυ.
       - modern:
         - de: Du warst gestern bei mir.
+          ja: 昨日はうちにいたね。
         grc:
           - παρ᾽ ἐμοὶ χθὲς ἦσθα.
       - modern:
         - de: Kommt heute in meine Wohnung!
+          ja: 今日は私の家においで！
         grc:
           - ἥκετ᾽ \emph{εἰς ἐμοῦ} τήμερον!
   - title:
       de: Sitzen. Stehen
+      ja: 座る・立つ
     conversations:
       - modern:
         - de: "Leg' ab!"
+          ja: 脱げ！
         grc:
           - ἀποδύου!
       - modern:
         - de: Ich ziehe mich schon aus.
+          ja: もう脱いでいるよ。
         grc:
           - καὶ δὴ ἐκδύομαι.
       - modern:
         - de: Wohin wollen wir uns setzen?
+          ja: どこに座ろうか？
         grc:
           - \emph{ποῦ} καθιζησόμεθα;
       - modern:
         - de: Nehmt Platz!
+          ja: 座ってください！
         grc:
           - κάθησθε!
       - modern:
         - de: Setzen Sie sich!
+          ja: お掛けください！
         - de: "Setz' dich nieder!"
+          ja: 座りなさい！
         grc:
           - κάθιζε!
       - modern:
         - de: Wenn du erlaubst!
+          ja: 君がよければ。
         grc:
           - εἰ ταῦτα \emph{δοκεῖ!}
       - modern:
         - de: So, ich sitze.
+          ja: よし、座った。
         grc:
           - ἰδού· κάθημαι.
       - modern:
         - de: Ich sitze schon!
+          ja: もう座っているよ。
         grc:
           - κάθημαι ᾽γὼ πάλαι.
       - modern:
         - de: Du hast keinen guten Platz.
+          ja: いい場所に座っていないね。
         grc:
           - οὐ καθίζεις ἐν καλῷ.
       - modern:
         - de: Hast du nichts zu essen?
+          ja: 食べるものがないの？
         grc:
           - οὐκ ἔχεις καταφαγεῖν;
       - modern:
         - de: \emph{Darf ich} dir ein Abendbrot vorsetzen?
+          ja: 夕食を出してもいいかい？
         grc:
           - βούλει παραθῶ σοι δόρπον.
       - modern:
         - de: Ich bitte nur um ein Stück Brot und Fleisch.
+          ja: パンと肉を少しだけいただければ十分です。
         grc:
           - αἰτῶ λαβεῖν τιν᾽ ἄρτον καὶ κρέας.!
       - modern:
         - de: Ich habe mir zu trinken \emph{mitgebracht}.
+          ja: 飲み物は持ってきました。
         grc:
           - \emph{ἥκω φέρων} πιεῖν.
       - modern:
         - de: Gieb mir einmal zu trinken!
+          ja: ちょっと飲み物をください。
         grc:
           - δός μοι πιεῖν.
       - modern:
         - de: Gleich.
+          ja: すぐ。
         grc:
           - ἰδού.
       - modern:
         - de: Es ist unrecht, daß du hier sitzest.
+          ja: ここに座っているのはよくない。
         grc:
           - ἀδικεῖς ἐνθάδε καθήμενος.
       - modern:
         - de: "Steh' \\emph{wieder} auf!"
+          ja: もう一度立て！
         grc:
           - ἀνίστασο!
       - modern:
         - de: "So steh' doch schnell auf, ehe dich jemand sieht!"
+          ja: 誰かに見られる前に早く立て！
         grc:
           - ούκουν ἀναστήσει ταχύ, πρίν τινά σ᾽ ἰδεῖν;
       - modern:
         - de: "Steh' gerade!"
+          ja: まっすぐ立て！
         grc:
           - ἀνίστασο ὀρθός.
       - modern:
         - de: "\\emph{Bleib'} stehen!"
+          ja: そのまま立っていろ！
         grc:
           - στῆθι.
       - modern:
         - de: Zu Befehl, Herr Hauptmann!
+          ja: 了解しました、隊長！
         grc:
           - ταῦτα, ὦ λοχαγέ!
   - title:
       de: Frau und Kinder
+      ja: 妻と子ども
     conversations:
       - modern:
         - de: Sie hat einen kleinen Jungen bekommen.
+          ja: 彼女は男の赤ちゃんを産んだ。
         grc:
           - ἄρρεν ἔτεκε παιδίον.
       - modern:
         - de: Er hat viele kleine Kinder zu ernähren.
+          ja: 彼には養うべき小さな子がたくさんいる。
         grc:
           - βόσκει μικρὰ πολλὰ παιδία.
       - modern:
         - de: Wo sind die Kinder?
+          ja: 子どもたちはどこだ？
         grc:
           - ποῦ τὰ παιδία;
       - modern:
         - de: Wo ist meine Frau hin?
+          ja: 私の妻はどこへ行った？
         grc:
           - ποῖ ἡ γυνὴ φρούδη ᾽στίν;
       - modern:
         - de: Wer kann mir sagen, wo meine Frau ist?
+          ja: 妻がどこにいるか誰か教えてくれませんか？
         grc:
           - τίς ἂν φράσειε, ποῦ ᾽στι ἡ γυνή;
       - modern:
         - de: Sie wäscht und päppelt das Kind.
+          ja: 彼女は子どもを洗って世話している。
         grc:
           - λούει καὶ ψωμίζει τὸ παιδίον.
       - modern:
         - de: Die Kinder sind gewaschen.
+          ja: 子どもたちは洗われている。
         grc:
           - ἀπονενιμμένα ἐστὶ τὰ παιδία.
       - modern:
         - de: Sie bringt die Kinder zu Bette.
+          ja: 彼女は子どもたちを寝かしつける。
         grc:
           - κατακλίνει τὰ παιδία.
       - modern:
         - de: Es ist \emph{höchste} Zeit.
+          ja: もういい時間だ。
         grc:
           - καιρὸς δέ.
       - modern:
         - de: Ihr habt lange genug gespielt.
+          ja: もう十分長く遊んだよ。
         grc:
           - ἱκανὸν κρόνον ἐπαίζετε.
       - modern:
         - de: Sie würfeln. — Um was?
+          ja: 彼らはサイコロを振っている――何を賭けているの？
         grc:
           - κυβεύουσιν. — περὶ τοῦ;
       - modern:
         - de: Sei artig!
+          ja: 行儀よくしなさい！
         grc:
           - κοσμίως ἔχε!
       - modern:
         - de: "Thu' das ja nicht!"
+          ja: 絶対それをするな！
         grc:
           - μηδαμῶς τοῦτ᾽ ἐργάσῃ!
       - modern:
         - de: "Da, schau' einmal!"
+          ja: ほら、見てごらん！
         grc:
           - ἰδού· θέασαι!
       - modern:
         - de: Der Onkel hat hübsche Geschenke mitgebracht.
+          ja: おじさんが素敵な贈り物を持ってきた。
         grc:
           - ὁ θεῖος ἥκει φέρων δῶρα χαρίεντα.!
       - modern:
         - de: Lies\textcompwordmark{}chen klatscht vor Freude in die Hände.
+          ja: リジヒェンは喜んで手を打っている。
         grc:
           - Λουίσιον{*} τὼ χεῖρ᾽ ἀνακροτεῖ ὑφ᾽ ἡδονῆς.!
       - modern:
         - de: Meine Frau ist nicht zu sehen.
+          ja: 妻の姿が見えない。
         grc:
           - ἡ δὲ γυνὴ \emph{φαίνεται.}
       - modern:
         - de: Suchst du mich etwa?
+          ja: もしかして私を探しているのか？
         grc:
           - μῶν ἐμὲ ζητεῖς;
       - modern:
         - de: Komm her, mein goldiger Schatz!
+          ja: こっちへおいで、かわいい宝物！
         grc:
           - δεῦρό νυν, ὦ χρυσίον.
   - title:
       de: Kinderkrawall
+      ja: 子どもたちの騒ぎ
     conversations:
       - modern:
         - de: Das ist Unrecht von dir.
+          ja: それはお前が悪い。
         grc:
           - ταῦτ’ οὐκ ὀρθῶς ποιεῖς.
       - modern:
         - de: Das ist unrecht, daß du mir das thust.
+          ja: そんなことを私にするのは間違っている。
         grc:
           - ἀδικεῖς γέ με τοῦτο ποιῶν.
       - modern:
         - de: "Wenn du mich ärgern willst, so soll dir's schlecht gehen!"
+          ja: もし私を怒らせるなら、ただでは済まないぞ！
         grc:
           - ἤν τι λυπῇς με, οὐ χαιρήσεις!
       - modern:
         - de: "Gieb mir's wieder!"
+          ja: それを返せ！
         grc:
           - ἀλλ’ ἀπόδος αὐτό!
       - modern:
         - de: Oder du sollst sehen (= ich ergreife andere Maßregeln)!
+          ja: さもないと痛い目にあわせるぞ！
         grc:
           - ἢ τἀπὶ τούτοις δρῶ.
       - modern:
         - de: Soll ich dir eine Ohrfeige geben?
+          ja: 頬を張ってやろうか？
         grc:
           - τὴν γνάθον βούλει θένω;
       - modern:
         - de: Das sollst du nicht umsonst gesagt haben!
+          ja: ただでそんなことを言ったと思うなよ！
         grc:
           - οὐ μὰ ∆ία σὺ καταπροίξει τοῦτο \emph{λέγων!}
       - modern:
         - de: Was hast du vor?
+          ja: 何をしようとしている？
         grc:
           - τί μέλλεις δρᾶν;
       - modern:
         - de: Du sollst gehörige Prügel bekommen.
+          ja: たっぷり叩いてやるからな。
         grc:
           - κλαύσει μακρά.
       - modern:
         - de: "(Daß du berstest!) Hol' dich der Kuckuck!"
+          ja: くたばってしまえ！
         grc:
           - διαρραγείης!
       - modern:
         - de: Da hast du eine Backpfeife!
+          ja: ほら、ビンタだ！
         grc:
           - οὑτοσί σοι κόνδυλος!
       - modern:
         - de: "Zum Donnerwetter!Immer hau' ihn!"
+          ja: ちくしょう！どんどん殴れ！
         grc:
           - ἐς κόρακας!
       - modern:
         - de: "Wart', ich will dir's weisen!"
+          ja: 待て、思い知らせてやる！
         grc:
           - παῖε παῖε!
       - modern:
         - de: Kommt mir nicht zu nahe!
+          ja: 近寄るな！
         grc:
           - μὴ πρόσιτε.
       - modern:
         - de: Hurrah!
+          ja: 万歳！
         grc:
           - ἀλαλαί!
       - modern:
         - de: Jetzt haben wir ihn!
+          ja: これで捕まえたぞ！
         grc:
           - νῦν ἔχεται μέσος!
       - modern:
         - de: Wollt ihr weg!
+          ja: 出て行け！
         grc:
           - οὐχὶ σοῦσθε;
       - modern:
         - de: Wir sollt ihr nicht wieder kommen!
+          ja: 二度と戻ってくるな！
         grc:
           - οὐδὲν ἄν με φλαῦρον ἔτι ἐργάσαισθε.
   - title:
       de: Kinderzucht
+      ja: 子どものしつけ
     conversations:
       - modern:
         - de: Was ist das für ein Lärm da drin?
+          ja: 中で何の騒ぎだ？
         grc:
           - τίς οὗτος ὁ ἔνδον θόρυβος;
       - modern:
         - de: Schreit nicht so!
+          ja: そんなに騒ぐな！
         grc:
           - μὴ βοᾶτε! — μὴ βοᾶτε μηδαμῶς! — μὴ κεκράγατε!
       - modern:
         - de: So hört doch endlich!
+          ja: もう黙りなさい！
         grc:
           - οὐκ ἄκούσεσθε ἐτεόν;
       - modern:
         - de: "Was giebt's?"
+          ja: 何があった？
         grc:
           - τί ἔστιν;
       - modern:
         - de: Was ist los? Um was handelt es sich?
+          ja: どうしたんだ、何の用だ？
         grc:
           - τί τὸ πρᾶγμα;
       - modern:
         - de: Wer schreit \emph{nach mir?}
+          ja: 誰が私を呼んで叫んでいるんだ？
         grc:
           - τίς ὁ βοῶν με;
       - modern:
         - de: "Soll ich's sagen?"
+          ja: 言いましょうか？
         grc:
           - εἴπω;
       - modern:
         - de: Erzähle es mir!
+          ja: 私に話してごらん。
         grc:
           - κάτειπέ μοι.
       - modern:
         - de: Karl hat uns geprügelt.
+          ja: カールが僕たちを殴った。
         grc:
           - Κάρολος πληγὰς ἡμῖν ἐνέβαλλεν.
       - modern:
         - de: "Ist's möglich?"
+          ja: 本当か？
         grc:
           - τί φής!
       - modern:
         - de: Und was war dir Ursache davon?
+          ja: それで原因は何だったんだ？
         grc:
           - ἡ δ’ αἰτία τίς ἦν;
       - modern:
         - de: Warum?
+          ja: なぜだ？
         grc:
           - τιή;
       - modern:
         - de: So hitzig?
+          ja: そんなに短気なのか？
         grc:
           - ὡς ὀξύθυμος!
       - modern:
         - de: Das ist immer so deine Art!
+          ja: それがいつもの君のやり方だ。
         grc:
           - οὗτος ὁ τρόπος πανταχοῦ!
       - modern:
         - de: Ich bin nicht schuld daran.
+          ja: 私のせいではない。
         grc:
           - οὐκ ἐγὼ τούτων αἴτιος.
       - modern:
         - de: Ja mit mir hat er es ebenso gemacht.
+          ja: ああ、私にも同じことをした。
         grc:
           - νὴ ∆ία, κἀμὲ τοῦτ’ ἔδρασε ταὐτόν.
       - modern:
         - de: Du willst es in Abrede stellen?
+          ja: 否定するつもりか？
         grc:
           - ἀρνεῖ;
       - modern:
         - de: Nicht gemuckst!
+          ja: 黙っていろ！
         grc:
           - μὴ γρύξῃς!
       - modern:
         - de: Daß du mir keine Lügen sagst!
+          ja: 嘘は言うなよ！
         grc:
           - ὅπως ἐρεῖς μηδὲν ψεῦδος!
       - modern:
         - de: Du verdienst Schläge.
+          ja: お前は殴られて当然だ。
         grc:
           - ἄξιος εἶ πληγὰς λαβεῖν.
       - modern:
         - de: "Du, halt' einmal! Wo rennst du hin?"
+          ja: おい、ちょっと待て！どこへ走っていく？
         grc:
           - ἐπίσχες, οὗτος! ποῖ θεῖς;
       - modern:
         - de: Sei nicht böse, lieber Vater!
+          ja: 怒らないで、お父さん！
         grc:
           - μηδὲν ἀγανάακτει, ὦ πάτερ!
       - modern:
         - de: Man muß sich todtärgern!
+          ja: もう腹が立ってたまらない！
         grc:
           - οἴμοι, διαρραγήσομαι.

--- a/part-g.yaml
+++ b/part-g.yaml
@@ -1,218 +1,274 @@
 part:
   de: Aus dem politischen Leben.
+  ja: 政治生活より
 sections:
   - title:
       de: Parteibewegung
+      ja: 政党運動
     conversations:
       - modern:
         - de: Eugen ist da?
+          ja: オイゲンは来ていますか？
         grc:
           - ὁ Εὐγενὴς ἐπιδεδήμεκεν;
       - modern:
         - de: Schon seit vorgestern.
+          ja: おとといからもう来ています。
         grc:
           - τρίτην ἤδη ἡμέραν.
       - modern:
         - de: Er wird doch wohl eine Rede halten?
+          ja: 彼は演説をするのでしょう？
         grc:
           - \emph{οὐκοῦν} δημηγορήσει;
       - modern:
         - de: Versteht sich! Heute Abend.
+          ja: もちろんです。今晩に。
         grc:
           - εὖ ἴσθ᾽ ὅτι εἰς ἑσπέραν.
       - modern:
         - de: Worüber? Über alles Mögliche.
+          ja: 何について？あらゆることについてです。
         grc:
           - περὶ τοῦ; περὶ \emph{ἁπάντων} πραγμάτων.
       - modern:
         - de: Ich will Sie mit in die Versammlung nehmen.
+          ja: 会合にご一緒しましょう。
         grc:
           - \emph{ἄξω} σε μετ᾽ ἐμαυτοῦ εἰς τὸν σύλλογον.
       - modern:
         - de: Ich danke, ich weiß den Weg.
+          ja: ありがとう、道は知っています。
         grc:
           - καλῶς· ἀλλ᾽ οἶδα τὴν ὁδόν.
       - modern:
         - de: |-
             Nun, so machen Sie denn, daß Sie \emph{auch} hinkommen und bringen
             Sie noch ein paar Andere mit!
+          ja: ではあなたもぜひ来て、ほかの人も何人か連れてきてください。
         grc:
           - ἀλλ᾽ ὅπως παρέσει καὶ αὐτὸς καὶ ἄλλους \emph{ἄξεις!}
       - modern:
         - de: Die Fort\textcompwordmark{}schrittler.
+          ja: 進歩派。
         grc:
           - οἱ καινοτομοῦντες.
       - modern:
         - de: Die Conservativen.
+          ja: 保守派。
         grc:
           - οἱ συντηρητικοί.{*}
       - modern:
         - de: Die Rothen.
+          ja: 急進派（赤）。
         grc:
           - οἱ δημοκρατικοί.
       - modern:
         - de: Das Parlament.
+          ja: 議会。
         grc:
           - ἡ βουλή.
       - modern:
         - de: Die Commission.
+          ja: 委員会。
         grc:
           - οἱ ἐπίτροποι.
       - modern:
         - de: Der Abgeordnete.
+          ja: 代議士。
         grc:
           - ὁ βουλευτής.
       - modern:
         - de: Der Wahlkandidat.
+          ja: 立候補者。
         grc:
           - ὁ ὑπόψηφος.
       - modern:
         - de: Die Majorität.
+          ja: 多数派。
         grc:
           - οἱ πλείονες.
       - modern:
         - de: Die Minorität.
+          ja: 少数派。
         grc:
           - οἱ μείονες.
       - modern:
         - de: Die Präsident.
+          ja: 議長。
         grc:
           - ὁ πρόεδρος.
       - modern:
         - de: Wer hat die meisten (wenigsten) \emph{Stimmen?}
+          ja: だれが最多（最少）の得票を得ましたか？
         grc:
           - τίνι πλεῖσται (ἐλάχισται) γεγόνασιν;
       - modern:
         - de: Abgeordneter ist, wer die meisten \emph{Stimmen} bekommen hat.
+          ja: 最も多く票を得た者が代議士です。
         grc:
           - βουλευτής ἐστιν, ᾧ ἂν πλεῖσται γένωνται.
       - modern:
         - de: Ist A.\ gewählt?
+          ja: Aは当選しましたか。
         grc:
           - πότερον Ἀ.\ ᾑρέθη;
       - modern:
         - de: Leider nicht!
+          ja: 残念ながら落選しました。
         grc:
           - εἰ γὰρ ὤφερε!
   - title:
       de: Opposition
+      ja: 反対派
     conversations:
       - modern:
         - de: Wir brauchen keine neuen \emph{Steuern!}
+          ja: 新しい税金など必要ありません！
         grc:
           - οὐ δεόμεθα καινῶν δασμῶν!
       - modern:
         - de: Wir \emph{brauchen} keine neuen Steuern!
+          ja: 私たちは本当に新税を要しません！
         grc:
           - καινῶν δασμῶν οὐ δεόμεθα!
       - modern:
         - de: Das wird uns ruiniren!
+          ja: それでは破滅してしまう！
         grc:
           - τοῦθ᾽ ἡμᾶς ἐπιτρίψει!
       - modern:
         - de: Ich denke, es giebt einen Mittelweg.
+          ja: 折衷案があると思います。
         grc:
           - ἀλλ᾽ εἶναί τί μοι δοκεῖ μέση τούτων ὁδός.
       - modern:
         - de: Jetzt ist Schonung der Steuerkraft nöthig!
+          ja: 今は租税負担を抑えるべきです！
         grc:
           - νῦν \emph{ἔργον} εὐτελείας!
       - modern:
         - de: Die Kolonialpolitik bringt keinen Nutzen.
+          ja: 植民政策は利益をもたらしません。
         grc:
           - τί \emph{πλέον ἐστὶν} ἔξω ἐποικεῖν;
       - modern:
         - de: Das gefällt mir nicht!
+          ja: それは気に入りません。
         grc:
           - τοῦτό μ᾽ οὐκ ἀρέσκει!
       - modern:
         - de: Dahinter steckt etwas!
+          ja: 何か裏があります！
         grc:
           - ἔστιν ἐνταῦθά τι κακόν!
       - modern:
         - de: Was hat man davon?
+          ja: それで何の得がありますか。
         grc:
           - τί κέρδος;
       - modern:
         - de: Was werden wir davon haben?
+          ja: 私たちにどんな利益がありますか。
         grc:
           - τί κερδανοῦμεν;
       - modern:
         - de: Was kann das nützen?
+          ja: 何の役に立つでしょうか。
         grc:
           - πῶς ξυνοίσει ταῦτα;
       - modern:
         - de: Ich weiß schon, wo man hinaus\textcompwordmark{}will!
+          ja: 何を狙っているかもう分かっています。
         grc:
           - οἶδα τὸν νοῦν!
       - modern:
         - de: Fort mit Bis\textcompwordmark{}marck!
+          ja: ビスマルクはもうたくさんだ！
         grc:
           - Βίσμαρκ ἐρρέτω!
       - modern:
         - de: Bravo! Bravo!
+          ja: ブラボー！ブラボー！
         grc:
           - εὖγε! εὖγε!
       - modern:
         - de: Wie gut ist es, einen so vortrefflichen Abgeordneten zu haben!
+          ja: こんな立派な代議士がいてありがたいことです！
         grc:
           - ὡς ἀγαθὸν τοιοῦτον ἔχειν βουλευτήν!
       - modern:
         - de: Unsinn!
+          ja: ばかげている！
         grc:
           - οὐδὲν λέγεις!
       - modern:
         - de: Wir hängen diese Tiraden zum Halse heraus!
+          ja: もうこんな長広舌にはうんざりだ！
         grc:
           - πάνυ μοι ἤδη ταῦτ᾽ ἐστὶ χολή.
       - modern:
         - de: Still!
+          ja: 静かに！
         grc:
           - σίγα!
   - title:
       de: Zum Schlutz
+      ja: 結びに
     conversations:
       - modern:
         - de: Wer wünscht das Wort?
+          ja: 誰か発言を希望しますか。
         grc:
           - τίς ἀγορεύειν βούλεται;
       - modern:
         - de: Ich.
+          ja: 私です。
         grc:
           - ἐγώ.
       - modern:
         - de: Ist noch Jemand, der zu sprechen wünscht?
+          ja: ほかに発言したい人はいますか。
         grc:
           - ἔσθ᾽ ὅστις ἕτερος βούλεται λέγειν;
       - modern:
         - de: Es wird wohl Niemand dagegen stimmen.
+          ja: 反対票を投じる人はいないでしょう。
         grc:
           - οὐ δεὶς ἀντιχειροτονήσειεν ἄν.
       - modern:
         - de: Ich stimme dagegen.
+          ja: 私は反対に投票します。
         grc:
           - ἐγὼ τἀναντία ψηφίζομαι.
       - modern:
         - de: "So ist's recht."
+          ja: それで結構。
         grc:
           - καλῶς γε ποιῶν.
       - modern:
-        - de: "Thu', was du \\emph{denkst!}"
+        - de: "Thu', was du \emph{denkst!}"
+          ja: 思うとおりにしなさい。
         grc:
           - ποίει, ὅτι ἄν σοι δοκῇ.
       - modern:
         - de: Was ist heute berathen worden?
+          ja: 今日は何が協議されましたか。
         grc:
           - τί βεβούλεται τήμερον;
       - modern:
         - de: Was hat man denn beschlossen?
+          ja: では何が決まりましたか。
         grc:
           - τί δῆτ᾽ ἔδοξεν;
       - modern:
         - de: Noch nichts; es war \emph{Stimmen}gleichheit.
+          ja: まだ何も決まっていません；票が同数でした。
         grc:
           - οὐδέν πω· ἶσαι γὰρ ἐγένοντο.
       - modern:
         - de: Eine so unsinnige Versammlung habe ich noch nicht erlebt.
+          ja: こんな馬鹿げた会合は初めてです。
         grc:
           - τοιοῦτον σύλλογον οὔπω \emph{ὄπωπα.}
+          - ὃ δοκεῖ σοι, ποίει.

--- a/part-h.yaml
+++ b/part-h.yaml
@@ -1,214 +1,267 @@
 part:
   de: Beim Skat\textcompwordmark{}spiel.
+  ja: スカート（Skat）をするとき
 sections:
   - title:
       de: Ein Spiel mit Redens\textcompwordmark{}arten
+      ja: 言い回しを交えた一局
     conversations:
       - modern:
         - de: Wollen wir nicht ein Spielchen machen?
+          ja: 一局やりませんか。
         grc:
           - βούλεσθε παιδιὰν παίζωμεν;
       - modern:
         - de: Meinetwegen.
+          ja: いいですよ。
         grc:
           - \emph{οὐδὲν κωλύει.}
       - modern:
         - de: Was wollen wir spielen?
+          ja: 何をしましょうか。
         grc:
           - παιδιὰν τίνα;
       - modern:
         - de: Einen Skat wollen wir machen.
+          ja: スカートをやりましょう。
         grc:
           - (σκατιούμεθα).
       - modern:
         - de: Wer giebt?
+          ja: 誰が札を配りますか。
         grc:
           - τίς ὁ διαδώσων;
       - modern:
         - de: Ich frage.
+          ja: 私が声をかけます。
         grc:
           - ἐμὸν τὸ ἐρωτᾶν.
       - modern:
         - de: Eichel, Grün, Roth, Schellen.
+          ja: どんぐり、葉、赤（ハート）、鈴だ。
         grc:
           - τὰ βαλάνια, τὰ φυλλεῖα, τὰ ἐρυθρά, τά κρόταλα.
       - modern:
         - de: Eichel sticht.
+          ja: どんぐりが切り札だ。
         grc:
           - κρατεῖ τὰ βαλάνια.
       - modern:
         - de: Geben Sie Grün zu!
+          ja: 葉の札を出してください！
         grc:
           - ἀπόδος φυλλεῖα!
       - modern:
         - de: Ich?
+          ja: 私が？
         grc:
           - ἐγώ;
       - modern:
         - de: Freilich (Sie)!
+          ja: もちろん、あなたです！
         grc:
           - σὺ μέντοι!
       - modern:
         - de: Was habe ich davon?
+          ja: それで私は何の得がありますか。
         grc:
           - τί κερδανῶ;
       - modern:
         - de: Was ich für ein Pech habe!
+          ja: なんてついてないんだ！
         grc:
           - ὡς δυστυκής εἰμι!
       - modern:
         - de: Nur nicht ängstlich!
+          ja: おどおどするな！
         grc:
           - μὴ δέδιθι!
       - modern:
         - de: Sehen Sie sich vor, daß Ihnen der rothe Wenzel nicht entgeht!
+          ja: 赤のヴェンツェルを取り逃がさないよう気をつけて！
         grc:
           - εὐλαβοῦ, μὴ ἐκφύγῃ σε τῶν ἐρυθρῶν ὁ κράτιστος!
       - modern:
         - de: "Jetzt ist's an Ihnen, zu sehen, wie wir gewinnen!"
+          ja: さあ、どうやって勝つか考えるのはあなたの役目です！
         grc:
           - σὸν \emph{ἔργον} φροντίζειν, ὅπως κρατήσομεν.
       - modern:
         - de: Jetzt gilt es!
+          ja: 今が勝負どころです！
         grc:
           - νῶν ὁ καιρός!
       - modern:
         - de: Jetzt haben wir ihn!
+          ja: これで押さえたぞ！
         grc:
           - νῶν ἔχεται μέσος!
       - modern:
         - de: "Hau' ihm, Lucas!"
+          ja: やっちまえ、ルーカス！
         grc:
           - παῖε, παῖε τὸν πανοῦργον!
       - modern:
         - de: |-
             Das soll Ihnen schlecht bekommen, daß Sie das rothe Daus gestochen
             haben!
+          ja: 赤のダウスを取ったのだから、ただではすみませんよ！
         grc:
           - οὔ τοι μὰ Δία χαιρήσεις, ὁτιὴ τοῦτ᾽ ἔδρασας.!
       - modern:
         - de: Verwünscht! Das ist zum Haaraus\textcompwordmark{}raufen!
+          ja: ちくしょう、髪をかきむしりたいほどだ！
         grc:
           - οἴμοι, διαρραγήσομαι!
       - modern:
         - de: Ich weiß schon, wie Sie es machen.
+          ja: あなたの手口は分かっています。
         grc:
           - τοὺς τρόπους σου ἐπίσταμαι.
       - modern:
         - de: Feine Rase!
+          ja: 見事な差し方だ！
         grc:
           - εὖ γε ξυνέβαλες!
       - modern:
         - de: Du wunderst dich?
+          ja: 驚いたか？
         grc:
           - ἐθαύμασας;!
       - modern:
         - de: Darin bin ich Meister.
+          ja: それはお手のものだ。
         grc:
           - ταύτεῃ κράτιστός εἰμι.
       - modern:
         - de: Sie spielen falsch!
+          ja: 反則をしていますね！
         grc:
           - ἀδικεῖς!
       - modern:
         - de: Du hast die Mogelei nicht bemerkt.
+          ja: ごまかしに気づかなかったろう。
         grc:
           - τὸ πραττόμενόν σε λέληθεν.
       - modern:
         - de: Ist das wahr?
+          ja: 本当ですか。
         grc:
           - τί λέγεις;
       - modern:
         - de: Ent\textcompwordmark{}schuldigen Sie!
+          ja: 失礼！
         grc:
           - σύγγνωθί μοι!
       - modern:
         - de: Kellner, zünden Sie Licht an!
+          ja: ウェイター、灯りをつけて！
         grc:
           - ἅπτε, παῖ, λύχνον!
       - modern:
         - de: Was fällt Ihnen denn ein, daß Sie die Zehn aus\textcompwordmark{}spielen?
+          ja: どうして十を切ったんですか。
         grc:
           - τί δὴ μαθὼν τοῦτο ποιεῖς;
       - modern:
         - de: Die Noth zwingt mich dazu.
+          ja: それしか手がなかったんです。
         grc:
           - ἡ ἀνάγκη με πιέζει.
       - modern:
         - de: Verwünscht! was soll ich thun?
+          ja: ちくしょう、どうしたらいい？
         grc:
           - οἴ μοι, τί δράςω;
       - modern:
         - de: Geben Sie mir einen guten Rath!
+          ja: いい助言をください！
         grc:
           - χρηστόν τι συμβούλευσον.
       - modern:
         - de: "Er will's gewinnen."
+          ja: 彼はそれを取りに行くつもりだ。
         grc:
           - ἐθέλει οὗτος κρατῆσαι.
       - modern:
         - de: Geben Sie sich keine vergebliche Mühe!
+          ja: むだな努力はやめなさい！
         grc:
           - λίθον ἕψεις!
       - modern:
         - de: Hilf Himmel!
+          ja: 天よ助けて！
         grc:
           - Ἄπολλον ἀποτρόπαιε!
       - modern:
         - de: "O weh! Jetzt geht's uns (zweien) schlecht!"
+          ja: うわぁ、これで俺たち二人はまずいぞ！
         grc:
           - ἒ ἔ, παρὰ νῷν στενάζειν!
       - modern:
         - de: Gerade das will ich ja!
+          ja: それこそ望むところだ。
         grc:
           - τοῦτ᾽ αὐτὸ γὰρ καὶ βούλομαι!
       - modern:
         - de: Zähle einmal!
+          ja: 点を数えてみて！
         grc:
           - λόγισαι!
       - modern:
         - de: Wir haben verspielt!
+          ja: 私たちは負けてしまった！
         grc:
           - \emph{ἀπολώλαμεν} ἡμεῖς.
       - modern:
         - de: Bitte, bezahlen Sie!
+          ja: お支払いください！
         grc:
           - ἀπότισον \emph{δῆτα!}
       - modern:
         - de: Mein Geld ist futsch!
+          ja: 私の金が消えた！
         grc:
           - φροῦδα τὰ χρήματα!
       - modern:
         - de: Es steht schlecht mit mir.
+          ja: 私の状況はひどいです。
         grc:
           - φαῦλόν ἐστι τὸ ἐμὸν πρᾶγμα.
       - modern:
         - de: Wir machen miserable Geschäfte.
+          ja: 私たちはひどい結果でした。
         grc:
           - ἀθλίως πεπράγαμεν.
   - title:
       de: Ein Grand
+      ja: グランドの一局
     conversations:
       - modern:
         - de: (Ein Grand.)
+          ja: （グランドのゲーム。）
         grc:
           - (τὸ παμμέγιστον.)
       - modern:
         - de: A. Wer giebt denn?
+          ja: さて誰が札を配る？
         grc:
           - τίς ὁ διαδώσων;
       - modern:
         - de: B. Du selbst.
+          ja: お前だよ。
         grc:
           - αὐτὸς σύ.
       - modern:
         - de: C. Immer, wer fragt.
+          ja: いつだって、言い出した人間が配るんだ。
         grc:
           - ὁ ἀεὶ ἐρωτήσας.
       - modern:
         - de: |-
             B. Nun gieb mir aber einmal anständige Karten; ich habe den ganzen
             Abend noch kein Spiel gehabt!
+          ja: B. じゃあ今度こそまともな札をくれよ。今夜は一度もまともな手がなかったんだ！
         grc:
           - |-
             δός τι δῆτ᾽ ἐμοὶ· οὐδὲν γὰρ πώποτ᾽ ἔλαβον ἔγωγε τῇδε τῇ\footnote{\textgreek{%
@@ -216,110 +269,135 @@ sections:
             } ἑσπέρᾳ!
       - modern:
         - de: C. Ich frage. Grün Solo!
+          ja: C. 俺が入札する。グリューンのソロだ！
         grc:
           - |-
             ἐμὸν τὸ ἐρωτᾶν. τὰ φυλλεῖα αὐτὰ\footnote{\textgreek{τὸ ῥῆμα οὐ δύναμαι διαγνῶναι.}%
             } καθ᾽ αὑτά!
       - modern:
         - de: "B. Das halt' ich!"
+          ja: B. それなら受けて立つ！
         grc:
           - ἔχω ἔγωγε!
       - modern:
         - de: C. Null?
+          ja: C. ヌルはどうだ？
         grc:
           - τὸ μηδέν;
       - modern:
         - de: B. Auch das.
+          ja: B. それも受けよう。
         grc:
           - καὶ τοῦτό γε.
       - modern:
         - de: C. Passe.
+          ja: C. パス。
         grc:
           - παραχωρῶ ἔγωγε.
       - modern:
         - de: A. Ich auch.
+          ja: A. 俺もパスだ。
         grc:
           - κἀγώ.
       - modern:
         - de: B. Grand.
+          ja: B. グランドで行く。
         grc:
           - τὸ παμμέγιστον.
       - modern:
         - de: "B. Ich spiele selbst aus. Hier! Wenzel 'raus!"
+          ja: B. 親は俺だ。さあ、ヴェンツェルを出すぞ！
         grc:
           - ἐμὸν τὸ ἐξάρχειν. ἰδού. ἀπόδοτε δὴ τοὺς κρατίστους!
       - modern:
         - de: C. Ja, den kann ich nicht!
+          ja: C. その札には合わせられない！
         grc:
           - οὐ δυνατὸς ἐγὼ μὰ Δία ὑπὲρ τοῦτον.
       - modern:
         - de: A. Nanu?!
+          ja: A. なんだって？
         grc:
           - τί φής;
       - modern:
         - de: B. Hurrah! Der Alte liegt im Skat! Hier!
+          ja: B. やった！長老札（オーバーのジャック）がスカートにあったぞ！ほら！
         grc:
           - βαβαιάξ! ἀπόκειται ὁ παγκράτιστος! ἰδού
       - modern:
         - de: C. Himmeldonnerwetter!
+          ja: C. ちくしょうめ！
         grc:
           - ἐς κόρακας!
       - modern:
         - de: A. Kreuzmillionen . . .!
+          ja: A. なんてこった……！
         grc:
           - Ἄπολλον ἀποτρόπαιε!
       - modern:
         - de: "C. Ih, da soll doch der Deiwel 'reinfahren!"
+          ja: C. くそ、悪魔でも持っていけ！
         grc:
           - οἴμοι κακοδαίμων!
       - modern:
         - de: A. Heiliges Gewitter! Hast du denn gar nichts?
+          ja: A. 何てこった！お前、本当に何も持ってないのか？
         grc:
           - |-
             ὦ Ζεῦ βασιλεῦ! οὐκ ἄρ᾽ ἔχεις\footnote{\textgreek{τὸ ῥῆμα οὐ δύναμαι διαγνῶναι.}%
             } οὐδέν;
       - modern:
         - de: "C. Dieser ist unser! 'rin, was Beine hat!"
+          ja: C. これは俺たちの取り分だ！動ける札は全部突っ込め！
         grc:
           - ἀλλὰ τοῦτό γε γίγνεται ἥμῖν. νῦν ὁ καιρὸς ἐπιδοῦναι!
       - modern:
         - de: B. Halt! Gesprochen wird nicht beim Spiel!
+          ja: B. やめろ！プレイ中はしゃべらない！
         grc:
           - μὴ δῆτα — οὐ γὰρ ἔστι λαλεῖν τῷ παίζοντι!
       - modern:
         - de: C. So, das ist auch unser!
+          ja: C. よし、これもこっちのものだ！
         grc:
           - ἰδοὺ καὶ τοῦτο ἡμῖν!
       - modern:
         - de: Gottlob! Aus dem Schneider wären wir!
+          ja: やれやれ、シュナイダーは免れたぞ！
         grc:
           - τὸ μέσον καλῶς τετμήκαμεν!
       - modern:
         - de: A. Oh, wir kriegen noch viel mehr!
+          ja: A. まだまだもっと取れるさ！
         grc:
           - ἕξομεν ἔτι πολλῷ πλέον, ὦ τάν.
       - modern:
         - de: B. Keinen Stich! Der Rest ist mein!
+          ja: B. もう一つも取らせない。残りは全部私のものだ！
         grc:
           - οὐκ ἄλλ᾽ οὐδὲ ἕν. ἐμὰ γὰρ τὰ λοιπά!
       - modern:
         - de: A. u. C. Oho! — Wahrhaftig!
+          ja: A・C. なんだと！——本当に？
         grc:
           - οὐδὲν λέγεις! — μὰ τὸν Δί᾽ οὐ τοίνυν!
       - modern:
         - de: |-
             A. Ja wie konntest du aber auch \emph{die} Farbe spielen? Wir mußten
             ja dicke gewinnen!
+          ja: A. どうしてそこでそのスートを出したんだ？ こっちは大勝ちできたはずなのに！
         grc:
           - πῶς ἄρ᾽ οὖν ἐπὶ ταῦτα ἦλθες; ἐμέλλομεν γάρ τοι σφοδρῶς ὑπερέχειν!
       - modern:
         - de: Ich sitze hier mit der ganzen Grün.
+          ja: こっちは葉の札を全部抱えてるんだ。
         grc:
           - ἐγὼ δὲ κάθημαι οὕτω πάντα τὰ φυλλεῖα ἔχων.
       - modern:
         - de: |-
             C. So? Warum stichst du denn nicht? Ich habe ganz richtig aus\textcompwordmark{}gespielt.
             — du bist schuld!
+          ja: C. そうか？ じゃあなぜ切らなかった？ 俺は正しくリードしたぞ。——お前のせいだ！
         grc:
           - |-
             ἄληθες; τί δὴ παθὴν οὐχ ὑπερέβαλες\footnote{\textlatin{%
@@ -327,5 +405,6 @@ sections:
             } σύ; εὖ γὰρ ἐμοίησα ἔγωγε. — σὺ δὲ τούτου αἴτιος!
       - modern:
         - de: B. Das war Grand mit Vieren! Sechzig. Wer giebt?
+          ja: B. 今のはグランド・ミット・フィーアレンで六十点だ。次は誰が配る？
         grc:
           - παμμέγιστον τοῦτ᾽ ἦν μετὰ τεσσάρων! ἑξήκοντα. τίς ὁ διαδώσων;

--- a/part-i.yaml
+++ b/part-i.yaml
@@ -1,43 +1,54 @@
 part:
   de: "Sprichwörtliches aus der Umgangs\\textcompwordmark{}sprache."
+  ja: 日常会話のことわざ
 indexTitle:
   de: "Sprichwörtliches aus der Umgangs\\textcompwordmark{}sprache Altgriechische Bezeichnungen für moderne Begriffe"
+  ja: 日常会話のことわざ　古代ギリシア語で現代語をどう言うか
 sections:
   - conversations:
       - modern:
         - de: Mensch, ärgere dich nicht!
+          ja: まあ腹を立てるなよ！
         grc:
           - μὴ σεαυτὸν ἔσθιε, ὦ ᾽γαθέ!
       - modern:
         - de: Eines Mannes Rede ist keine Rede.
+          ja: 一人の話だけでは判断にならない。
         grc:
           - πρὶν ἂν ἀμφοῖν μῦθον ἀκούσῃς, οὐκ ἂν δικάσαις.
       - modern:
         - de: Das hieße Eulen nach Athen tragen.
+          ja: それではアテナイにフクロウを運ぶようなものだ。
         grc:
           - τίς γλαῦκ᾽ Ἀθήναζε ἄγαγεν;
       - modern:
         - de: Vorsicht ist die Mutter der Weis\textcompwordmark{}heit.
+          ja: 用心は知恵の母だ。
         grc:
           - ἡ (γὰρ) εὐλάβεια πάντα σώζει.
       - modern:
         - de: Eine Schwalbe macht noch keinen Sommer.
+          ja: ツバメが一羽来ても夏とは言えない。
         grc:
           - μία χελιδὼν ἔαρ οὐ ποιεῖ.
       - modern:
         - de: Menge dich nicht in meine Sachen!
+          ja: 私のことに口を出すな！
         grc:
           - μὴ τὸν ἐμὸν οἴκει οἶκον!!
       - modern:
         - de: Der reine Menschenfeind (Timon)!
+          ja: まったくの人嫌いだ（ティモンだ）！
         grc:
           - Τίμων \emph{καθαρός!}
       - modern:
         - de: Immer das alte Lied!
+          ja: またいつもの決まり文句だ！
         grc:
           - ὁ Διὸς Κόρινθος!
       - modern: # ToDo: Latin
         - la: Hic Rhodus, hic salta!
+          ja: ここがロドスだ、ここで跳べ！
         grc:
           - |-
             ἰδοὺ ἡ Ῥόδος\footnote{\textlatin{%
@@ -45,59 +56,73 @@ sections:
             }, ἰδοὺ καὶ τὸ πήδημα!
       - modern:
         - de: Ein trauriger Peter (Japper)!
+          ja: しょんぼりしたやつだ！
         grc:
           - Μυσῶν ἔσχατος!
       - modern:
         - de: Das Gute ist rar.
+          ja: 良いものは稀だ。
         grc:
           - ὀλίγον τὸ χρηστόν ἐστιν.
       - modern:
         - de: Es ist kein Vorwärts\textcompwordmark{}kommen (für uns).
+          ja: （私たちには）前進の見込みがない。
         grc:
           - οὔτε θέομεν οὔτ᾽ ἐλαύνομεν.!
       - modern:
         - de: Geld regiert die Welt.
+          ja: 金が世を動かす。
         grc:
           - ἅπαντα (γὰρ) τῷ πλουτεῖν ὑπήκοα.!
       - modern: # ToDo latin
         - la: Donec eris felix, multos numerabis amicos.
+          ja: 幸運なうちは友も多い。
         grc:
           - ζεῖ χύτρα, ζῇ φιλία.!
       - modern:
         - de: Durch Schaden wird man klug!
+          ja: 痛い目を見て人は賢くなる！
         grc:
           - \quotedblbase παθὼν δέ τε νήπιος ἔγνω.``
       - modern: # ToDo latin
         - la: Tempi passati!
+          ja: 過ぎ去った時代だ！
         grc:
           - πάλαι ποτ᾽ ἦσαν ἄλκιμοι Μιλήσιοι.
       - modern: # ToD latin
         - la: Ubi bene, ibi patria!
+          ja: 住みよい所こそ祖国だ！
         grc:
           - πατρὶς γάρ ἐστι πᾶσ᾽, ἵν ἂν πράττῃ τις εὖ.
       - modern:
         - de: Er ist der beste Bruder auch nicht!
+          ja: 彼だって決して善人ではない！
         grc:
           - ἐστὶ τοῦ πονηροῦ κόμματος.
       - modern: # ToDo latin
         - la: Parturiunt montes etc.
+          ja: 山の胎動、産んだのは鼠一匹。
         grc:
           - ὤδινεν ὄρος, εἶτα μῦν ἀπέτεκεν.
       - modern:
         - de: Du giebst dir vergebliche Mühe.
+          ja: 骨折り損だ。
         grc:
           - λίθον ἕψεις.
       - modern:
         - de: Das Übel ärger machen.
+          ja: 災いに拍車をかける。
         grc:
           - πλέον θάτερον ποιεῖν.
       - modern:
         - de: Eile mit Weile.
+          ja: 急がば回れ。
         grc:
           - |-
             σπεῦδε βραδέως!\textgerman{ (Wahlspruch
             des Kaisers Augustus.)}
       - modern:
         - de: Laß dir genügen!
+          ja: 分をわきまえて満足せよ！
         grc:
           - πλέον ἥμισυ παντός!


### PR DESCRIPTION
## Summary
- Add Japanese translations to YAML files `part-c.yaml` through `part-i.yaml`.

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ae6190c788321b5617f732e4e2c48)